### PR TITLE
ARGO-1205 API AuthN: Authentication method - use uuid

### DIFF
--- a/auth-methods/api_key_auth.go
+++ b/auth-methods/api_key_auth.go
@@ -7,14 +7,14 @@ import (
 	"strings"
 )
 
-func FindApiKeyAuthMethod(service string, host string, store stores.Store) (map[string]interface{}, error) {
+func FindApiKeyAuthMethod(serviceUUID string, host string, store stores.Store) (map[string]interface{}, error) {
 
 	var err error
 	var apiKeyAuthMap map[string]interface{}
 	var apiKeyAuthMaps []map[string]interface{}
 	var ok bool
 
-	if apiKeyAuthMaps, err = store.QueryAuthMethods(service, host, "api-key"); err != nil {
+	if apiKeyAuthMaps, err = store.QueryAuthMethods(serviceUUID, host, "api-key"); err != nil {
 		return apiKeyAuthMap, err
 	}
 

--- a/auth-methods/api_key_auth_test.go
+++ b/auth-methods/api_key_auth_test.go
@@ -16,20 +16,20 @@ func (suite *TestApiKeyAuthSuite) TestFindApiKeyMethod() {
 	mockstore.SetUp()
 
 	// normal case
-	expMap1 := map[string]interface{}{"type": "api-key", "service": "s1", "host": "host1", "port": 9000.0, "path": "test_path_1", "access_key": "key1"}
-	apk1, err1 := FindApiKeyAuthMethod("s1", "host1", mockstore)
+	expMap1 := map[string]interface{}{"type": "api-key", "service_uuid": "uuid1", "host": "host1", "port": 9000.0, "path": "test_path_1", "access_key": "key1"}
+	apk1, err1 := FindApiKeyAuthMethod("uuid1", "host1", mockstore)
 
 	// not found case
 	apk2, err2 := FindApiKeyAuthMethod("no service", "no host", mockstore)
 
 	// path not declared case
-	apk3, err3 := FindApiKeyAuthMethod("s2", "host3", mockstore)
+	apk3, err3 := FindApiKeyAuthMethod("uuid2", "host3", mockstore)
 
 	// port not declared case
-	apk4, err4 := FindApiKeyAuthMethod("s2", "host4", mockstore)
+	apk4, err4 := FindApiKeyAuthMethod("uuid2", "host4", mockstore)
 
 	// access key not declared case
-	apk5, err5 := FindApiKeyAuthMethod("s1", "host2", mockstore)
+	apk5, err5 := FindApiKeyAuthMethod("uuid1", "host2", mockstore)
 
 	suite.Equal(expMap1["port"], apk1["port"])
 	suite.Equal(expMap1["type"], apk1["type"])
@@ -57,20 +57,20 @@ func (suite *TestApiKeyAuthSuite) TestCreateApiKeyMethod() {
 	mockstore.SetUp()
 
 	// tests the normal case
-	am := map[string]interface{}{"type": "api-key", "service": "s_temp", "host": "h_temp", "port": 9000.0, "path": "/path/{{identifier}}?key={{access_key}}", "access_key": "key1"}
+	am := map[string]interface{}{"type": "api-key", "service_uuid": "s_temp", "host": "h_temp", "port": 9000.0, "path": "/path/{{identifier}}?key={{access_key}}", "access_key": "key1"}
 	_, err1 := CreateApiKeyAuthMethod(am, mockstore)
 	am1, _ := FindApiKeyAuthMethod("s_temp", "h_temp", mockstore)
 
 	// tests the case where access_key is not included
-	AmMissingAccessKey := map[string]interface{}{"type": "api-key", "service": "s_temp", "host": "h_temp", "port": 9000.0, "path": "/path/{{identifier}}?key={{access_key}}"}
+	AmMissingAccessKey := map[string]interface{}{"type": "api-key", "service_uuid": "s_temp", "host": "h_temp", "port": 9000.0, "path": "/path/{{identifier}}?key={{access_key}}"}
 	_, err2 := CreateApiKeyAuthMethod(AmMissingAccessKey, mockstore)
 
 	// tests the case where {{identifier}} is missing from path
-	AmInvalidPath1 := map[string]interface{}{"type": "api-key", "service": "s_temp", "host": "h_temp", "port": 9000.0, "path": "/path/?key={{access_key}}", "access_key": "key1"}
+	AmInvalidPath1 := map[string]interface{}{"type": "api-key", "service_uuid": "s_temp", "host": "h_temp", "port": 9000.0, "path": "/path/?key={{access_key}}", "access_key": "key1"}
 	_, err3 := CreateApiKeyAuthMethod(AmInvalidPath1, mockstore)
 
 	// tests the case where {{access_key}} is missing from path
-	AmInvalidPath2 := map[string]interface{}{"type": "api-key", "service": "s_temp", "host": "h_temp", "port": 9000.0, "path": "/path/{{identifier}}?key=", "access_key": "key1"}
+	AmInvalidPath2 := map[string]interface{}{"type": "api-key", "service_uuid": "s_temp", "host": "h_temp", "port": 9000.0, "path": "/path/{{identifier}}?key=", "access_key": "key1"}
 	_, err4 := CreateApiKeyAuthMethod(AmInvalidPath2, mockstore)
 
 	suite.Equal(am, am1)

--- a/auth-methods/auth_methods.go
+++ b/auth-methods/auth_methods.go
@@ -13,7 +13,7 @@ type AuthMethodsList struct {
 
 type AuthMethodCreator func(authM map[string]interface{}, store stores.Store) (map[string]interface{}, error)
 
-type AuthMethodFinder func(service string, host string, store stores.Store) (map[string]interface{}, error)
+type AuthMethodFinder func(serviceUUID string, host string, store stores.Store) (map[string]interface{}, error)
 
 var AuthMethodFinders = map[string]AuthMethodFinder{
 	"api-key": FindApiKeyAuthMethod,

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -188,7 +188,7 @@ paths:
            properties:
             type:
               type: string
-            service:
+            service_uuid:
               type: string
             host:
               type: string
@@ -317,7 +317,7 @@ definitions:
       host:
         type: string
         description: host of the service type
-      service:
+      service_uuid:
         type: string
         description: service type that the auth method is used
       port:

--- a/docs/v1/api_auth_methods.md
+++ b/docs/v1/api_auth_methods.md
@@ -23,7 +23,7 @@ curl -X POST -H "Content-Type: application/json"
             "host": "127.0.0.1",
             "path": "/path/{{identifier}}?key={{access_key}}",
             "port": 9000,
-            "service": "s1",
+            "service_uuid1": "da22b2d4-ba6c-43ca-b28d-400sd0a5d83e",
             "type": "api-key"
         }
  ```
@@ -42,7 +42,7 @@ curl -X POST -H "Content-Type: application/json"
             "host": "127.0.0.1",
             "path": "/path/{{identifier}}?key={{access_key}}",
             "port": 9000,
-            "service": "s1",
+            "service_uuid": "da22b2d4-ba6c-43ca-b28d-400sd0a5d83e",
             "type": "api-key"
         }
    ```
@@ -67,11 +67,11 @@ curl -X POST -H "Content-Type: application/json"
    
 ```json
 {
-    "access_key": "b328c3861f061f87cbd34cf34f36ba2ae20883a5",
+    "access_key": "key1",
     "host": "127.0.0.1",
     "path": "/v1/users:byUUID/{{identifier}}?key={{access_key}}",
     "port": 8081,
-    "service": "ams",
+    "service_uuid": "da22b2d4-ba6c-43ca-b28d-400sd0a5d83e",
     "type": "api-key"
 }
 ```
@@ -103,7 +103,7 @@ curl -X POST -H "Content-Type: application/json"
       "host": "host2",
       "path": "path",
       "port": 9000,
-      "service": "s1",
+      "service_uuid": "da22b2d4-ba6c-43ca-b28d-400sd0a5d83e",
       "type": "api-key"
     },
     {
@@ -111,7 +111,7 @@ curl -X POST -H "Content-Type: application/json"
       "host": "host1",
       "path": "path",
       "port": 9000,
-      "service": "s2",
+      "service_uuid": "da22b2d4-ba6c-43ca-b28d-400sd0a5d83a",
       "type": "api-key"
     }
   ]

--- a/handlers/auth_method_handlers_test.go
+++ b/handlers/auth_method_handlers_test.go
@@ -24,7 +24,7 @@ func (suite *AuthMethodHandlersTestSuite) TestAuthMethodListOne() {
  "host": "host1",
  "path": "test_path_1",
  "port": 9000,
- "service": "s1",
+ "service_uuid": "uuid1",
  "type": "api-key"
 }`
 
@@ -212,28 +212,28 @@ func (suite *AuthMethodHandlersTestSuite) TestAuthMethodListAll() {
    "host": "host1",
    "path": "test_path_1",
    "port": 9000,
-   "service": "s1",
+   "service_uuid": "uuid1",
    "type": "api-key"
   },
   {
    "host": "host2",
    "path": "test_path_1",
    "port": 9000,
-   "service": "s1",
+   "service_uuid": "uuid1",
    "type": "api-key"
   },
   {
    "access_key": "key1",
    "host": "host3",
    "port": 9000,
-   "service": "s2",
+   "service_uuid": "uuid2",
    "type": "api-key"
   },
   {
    "access_key": "key1",
    "host": "host4",
    "path": "test_path_1",
-   "service": "s2",
+   "service_uuid": "uuid2",
    "type": "api-key"
   }
  ]
@@ -265,7 +265,7 @@ func (suite *AuthMethodHandlersTestSuite) TestAuthMethodCreate() {
  "host": "host3",
  "path": "test_path_1/{{identifier}}?key={{access_key}}",
  "port": 9000,
- "service": "s1",
+ "service_uuid": "uuid1",
  "type": "api-key"
 }`
 
@@ -274,7 +274,7 @@ func (suite *AuthMethodHandlersTestSuite) TestAuthMethodCreate() {
  "host": "host3",
  "path": "test_path_1/{{identifier}}?key={{access_key}}",
  "port": 9000,
- "service": "s1",
+ "service_uuid": "uuid1",
  "type": "api-key"
 }`
 
@@ -414,12 +414,12 @@ func (suite *AuthMethodHandlersTestSuite) TestAuthMethodCreateUnsupportedAuthMet
  "host": "host3",
  "path": "test_path_1/{{identifier}}?key={{access_key}}",
  "port": 9000,
- "service": "s1",
+ "service_uuid": "uuid1",
  "type": "unsupported-type"
 }`
 	expRespJSON := `{
  "error": {
-  "message": "Field: type contains invalid data. unsupported-type is not yet supported by the service",
+  "message": "Field: type contains invalid data. unsupported-type is not yet supported by the serviceType",
   "code": 422,
   "status": "UNPROCESSABLE ENTITY"
  }
@@ -456,7 +456,7 @@ func (suite *AuthMethodHandlersTestSuite) TestAuthMethodCreateMissingServiceFiel
 }`
 	expRespJSON := `{
  "error": {
-  "message": "ServiceType was not found in the request body",
+  "message": "ServiceType UUID was not found in the request body",
   "code": 422,
   "status": "UNPROCESSABLE ENTITY"
  }
@@ -489,7 +489,7 @@ func (suite *AuthMethodHandlersTestSuite) TestAuthMethodCreateMissingHostField()
  "path": "test_path_1/{{identifier}}?key={{access_key}}",
  "port": 9000,
  "type": "api-key",
- "service": "s1"
+ "service_uuid": "uuid1"
 }`
 	expRespJSON := `{
  "error": {
@@ -526,7 +526,7 @@ func (suite *AuthMethodHandlersTestSuite) TestAuthMethodCreateMissingPortField()
  "host": "host3",
  "path": "test_path_1/{{identifier}}?key={{access_key}}",
  "type": "api-key",
- "service": "s1"
+ "service_uuid": "uuid1"
 }`
 	expRespJSON := `{
  "error": {
@@ -562,7 +562,7 @@ func (suite *AuthMethodHandlersTestSuite) TestAuthMethodCreateMissingPathField()
  "access_key": "key1",
  "host": "host3",
  "port": 9000,
- "service": "s1",
+ "service_uuid": "uuid1",
  "type": "api-key"
 }`
 	expRespJSON := `{
@@ -599,7 +599,7 @@ func (suite *AuthMethodHandlersTestSuite) TestAuthMethodCreateMissingAccessKeyFi
  "host": "host3",
  "path": "test_path_1/{{identifier}}?key={{access_key}}",
  "port": 9000,
- "service": "s1",
+ "service_uuid": "uuid1",
  "type": "api-key"
 }`
 	expRespJSON := `{
@@ -638,7 +638,7 @@ func (suite *AuthMethodHandlersTestSuite) TestAuthMethodCreateUnknownService() {
  "port": 9000,
  "path": "test_path_1/{{identifier}}?key={{access_key}}",
  "type": "api-key",
- "service": "unknown_service"
+ "service_uuid": "unknown_service"
 }`
 	expRespJSON := `{
  "error": {
@@ -676,7 +676,7 @@ func (suite *AuthMethodHandlersTestSuite) TestAuthMethodCreateUnknownHost() {
  "port": 9000,
  "path": "test_path_1/{{identifier}}?key={{access_key}}",
  "type": "api-key",
- "service": "s1"
+ "service_uuid": "uuid1"
 }`
 	expRespJSON := `{
  "error": {
@@ -714,11 +714,11 @@ func (suite *AuthMethodHandlersTestSuite) TestAuthMethodCreateUnknownAuthMethod(
  "port": 9000,
  "path": "test_path_1/{{identifier}}?key={{access_key}}",
  "type": "unknown_authM",
- "service": "unknown_service"
+ "service_uuid": "uuid1"
 }`
 	expRespJSON := `{
  "error": {
-  "message": "Field: type contains invalid data. unknown_authM is not yet supported by the service",
+  "message": "Field: type contains invalid data. unknown_authM is not yet supported by the serviceType",
   "code": 422,
   "status": "UNPROCESSABLE ENTITY"
  }
@@ -751,7 +751,7 @@ func (suite *AuthMethodHandlersTestSuite) TestAuthMethodCreateInvalidPathContent
  "host": "host3",
  "path": "test_path_1/{{identifier}}?key=",
  "port": 9000,
- "service": "s1",
+ "service_uuid": "uuid1",
  "type": "api-key"
 }`
 	expRespJSON := `{
@@ -789,7 +789,7 @@ func (suite *AuthMethodHandlersTestSuite) TestAuthMethodCreateInvalidPathContent
  "host": "host3",
  "path": "test_path_1?key={{access_key}}",
  "port": 9000,
- "service": "s1",
+ "service_uuid": "uuid1",
  "type": "api-key"
 }`
 	expRespJSON := `{
@@ -827,12 +827,12 @@ func (suite *AuthMethodHandlersTestSuite) TestAuthMethodCreateAlreadyExists() {
  "host": "host1",
  "path": "test_path_1?key={{access_key}}",
  "port": 9000,
- "service": "s1",
+ "service_uuid": "uuid1",
  "type": "api-key"
 }`
 	expRespJSON := `{
  "error": {
-  "message": "auth_methods.AuthMethod object with service: s1 already exists",
+  "message": "auth_methods.AuthMethod object with serviceType: uuid1 already exists",
   "code": 409,
   "status": "CONFLICT"
  }

--- a/handlers/service_type_handlers_test.go
+++ b/handlers/service_type_handlers_test.go
@@ -482,7 +482,7 @@ func (suite *ServiceTypeHandlersSuite) TestServiceTypeListAllEmptyList() {
 	mockstore := &stores.Mockstore{Server: "localhost", Database: "test_db"}
 	mockstore.SetUp()
 	// empty the store
-	mockstore.Services = []stores.QServiceType{}
+	mockstore.ServiceTypes = []stores.QServiceType{}
 
 	cfg := &config.Config{}
 	_ = cfg.ConfigSetUp("../config/configuration-test-files/test-conf.json")

--- a/servicetypes/service_type.go
+++ b/servicetypes/service_type.go
@@ -94,6 +94,35 @@ func FindServiceTypeByName(name string, store stores.Store) (ServiceType, error)
 	return service, err
 }
 
+// FindServiceTypeByUUID queries the datastore to find a service type associated with the provided argument uuid
+func FindServiceTypeByUUID(uuid string, store stores.Store) (ServiceType, error) {
+
+	var qServices []stores.QServiceType
+	var service ServiceType
+	var err error
+
+	if qServices, err = store.QueryServiceTypesByUUID(uuid); err != nil {
+		return ServiceType{}, err
+	}
+
+	if len(qServices) == 0 {
+		err = utils.APIErrNotFound("ServiceType")
+		return ServiceType{}, err
+	}
+
+	if len(qServices) > 1 {
+		err = utils.APIErrDatabase("Multiple service-types with the same uuid: " + uuid)
+		return ServiceType{}, err
+	}
+
+	if err := utils.CopyFields(qServices[0], &service); err != nil {
+		err = utils.APIGenericInternalError(err.Error())
+		return ServiceType{}, err
+	}
+
+	return service, err
+}
+
 // FindAllServiceTypes returns all the service types from the datastore
 func FindAllServiceTypes(store stores.Store) (ServiceList, error) {
 

--- a/servicetypes/service_type_test.go
+++ b/servicetypes/service_type_test.go
@@ -86,6 +86,35 @@ func (suite *ServiceTestSuite) TestFindServiceTypeByName() {
 	suite.Equal("Database Error: Multiple service-types with the same name: same_name", err3.Error())
 }
 
+func (suite *ServiceTestSuite) TestFindServiceTypeByUUID() {
+
+	mockstore := &stores.Mockstore{Server: "localhost", Database: "test_db"}
+	mockstore.SetUp()
+
+	// normal case
+	expS1 := ServiceType{"s1", []string{"host1", "host2", "host3"}, []string{"x509", "oidc"}, "api-key", "uuid1", "token", "2018-05-05T18:04:05Z"}
+	ser1, err1 := FindServiceTypeByUUID	("uuid1", mockstore)
+
+	// not found case
+	var expS2 ServiceType
+	ser2, err2 := FindServiceTypeByUUID("wrong_uuid", mockstore)
+
+	// same name
+	var expS3 ServiceType
+	// insert two service s with the same name
+	mockstore.InsertServiceType("s1", []string{"host1", "host2", "host3"}, []string{"x509", "oidc"}, "api-key", "same_uuid", "token", "2018-05-05T18:04:05Z")
+	mockstore.InsertServiceType("s1", []string{"host1", "host2", "host3"}, []string{"x509", "oidc"}, "api-key", "same_uuid", "token", "2018-05-05T18:04:05Z")
+	ser3, err3 := FindServiceTypeByUUID("same_uuid", mockstore)
+
+	suite.Equal(expS1, ser1)
+	suite.Equal(expS2, ser2)
+	suite.Equal(expS3, ser3)
+
+	suite.Nil(err1)
+	suite.Equal("ServiceType was not found", err2.Error())
+	suite.Equal("Database Error: Multiple service-types with the same uuid: same_uuid", err3.Error())
+}
+
 func (suite *ServiceTestSuite) TestFindAllServiceTypes() {
 
 	mockstore := &stores.Mockstore{Server: "localhost", Database: "test_db"}
@@ -94,7 +123,7 @@ func (suite *ServiceTestSuite) TestFindAllServiceTypes() {
 	// normal case outcome - all services
 	expQServicesAll := []ServiceType{
 		{Name: "s1", Hosts: []string{"host1", "host2", "host3"}, AuthTypes: []string{"x509", "oidc"}, AuthMethod: "api-key", UUID: "uuid1", RetrievalField: "token", CreatedOn: "2018-05-05T18:04:05Z"},
-		{Name: "s2", Hosts: []string{"host3", "host4"}, AuthTypes: []string{"x509"}, AuthMethod: "api-key", UUID: "uuid2", RetrievalField: "user_token", CreatedOn: "2018-05-05T18:04:05Z"},
+		{Name: "s2", Hosts: []string{"host3", "host4"}, AuthTypes: []string{"x509"}, AuthMethod: "api-key", UUID: "uuid2", 	RetrievalField: "user_token", CreatedOn: "2018-05-05T18:04:05Z"},
 		{Name: "same_name"},
 		{Name: "same_name"},
 	}
@@ -103,7 +132,7 @@ func (suite *ServiceTestSuite) TestFindAllServiceTypes() {
 
 	// normal case outcome - empty list
 	var empServ ServiceList
-	mockstore.Services = []stores.QServiceType{}
+	mockstore.ServiceTypes = []stores.QServiceType{}
 	serAll2, err2 := FindAllServiceTypes(mockstore)
 
 	suite.Equal(expServList, serAll1)

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -54,15 +54,33 @@ func (mongo *MongoStore) QueryServiceTypes(name string) ([]QServiceType, error) 
 	return qServices, err
 }
 
-func (mongo *MongoStore) QueryAuthMethods(service string, host string, typeName string) ([]map[string]interface{}, error) {
+func (mongo *MongoStore) QueryServiceTypesByUUID(uuid string) ([]QServiceType, error) {
+
+	var qServices []QServiceType
+	var err error
+
+	c := mongo.Session.DB(mongo.Database).C("service_types")
+
+	err = c.Find(bson.M{"uuid": uuid}).All(&qServices)
+
+	if err != nil {
+		log.Fatal("STORE", "\t", err.Error())
+		err = utils.APIErrDatabase(err.Error())
+		return []QServiceType{}, err
+	}
+
+	return qServices, err
+}
+
+func (mongo *MongoStore) QueryAuthMethods(serviceUUID string, host string, typeName string) ([]map[string]interface{}, error) {
 
 	var qAuthMethods []map[string]interface{}
 	var err error
 
 	query := bson.M{}
 
-	if service != "" && host != "" && typeName != "" {
-		query = bson.M{"type": typeName, "service": service, "host": host}
+	if serviceUUID != "" && host != "" && typeName != "" {
+		query = bson.M{"type": typeName, "service_uuid": serviceUUID, "host": host}
 	}
 
 	c := mongo.Session.DB(mongo.Database).C("auth_methods")

--- a/stores/store.go
+++ b/stores/store.go
@@ -4,6 +4,7 @@ type Store interface {
 	SetUp()
 	Close()
 	QueryServiceTypes(name string) ([]QServiceType, error)
+	QueryServiceTypesByUUID(uuid string) ([]QServiceType, error)
 	QueryAuthMethods(service string, host string, typeName string) ([]map[string]interface{}, error)
 	QueryBindingsByDN(dn string, host string) ([]QBinding, error)
 	QueryBindings(service string, host string) ([]QBinding, error)


### PR DESCRIPTION
Update auth method to use service type uuid instead of service name.
updated tests, docs and swagger