### PR TITLE
ARGO-1165 X509 API Call

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ Before you start, you need to issue a valid certificate.
    "certificate_key":"/path/to/key/localhost.key",
    "service_token": "some-token",
    "supported_auth_types": ["x509", "oidc"],
-   "supported_auth_methods": ["api-key", "x-api-token"]
+   "supported_auth_methods": ["api-key", "x-api-token"],
+   "verify_ssl": true
  }
  ```

--- a/auth-methods/auth_methods.go
+++ b/auth-methods/auth_methods.go
@@ -1,7 +1,9 @@
 package auth_methods
 
 import (
+	"github.com/ARGOeu/argo-api-authn/config"
 	"github.com/ARGOeu/argo-api-authn/stores"
+	"net/http"
 )
 
 type AuthMethod struct{}
@@ -14,12 +16,18 @@ type AuthMethodCreator func(authM map[string]interface{}, store stores.Store) (m
 
 type AuthMethodFinder func(serviceUUID string, host string, store stores.Store) (map[string]interface{}, error)
 
+type AuthMethodHandler func(data map[string]interface{}, store stores.Store, config *config.Config) (*http.Response, error)
+
 var AuthMethodFinders = map[string]AuthMethodFinder{
 	"api-key": FindApiKeyAuthMethod,
 }
 
 var AuthMethodCreators = map[string]AuthMethodCreator{
 	"api-key": CreateApiKeyAuthMethod,
+}
+
+var AuthMethodHandlers = map[string]AuthMethodHandler{
+	"api-key": ApiKeyAuthMethodHandler,
 }
 
 func FindAllAuthMethods(store stores.Store) (AuthMethodsList, error) {

--- a/bindings/binding.go
+++ b/bindings/binding.go
@@ -137,7 +137,7 @@ func FindAllBindings(store stores.Store) (BindingList, error) {
 	var bindings = []Binding{}
 
 	if qBindings, err = store.QueryBindings("", ""); err != nil {
-		return BindingList{Bindings:[]Binding{}}, err
+		return BindingList{Bindings: []Binding{}}, err
 	}
 
 	// convert the QBindings to Bindings
@@ -145,12 +145,12 @@ func FindAllBindings(store stores.Store) (BindingList, error) {
 		_binding := &Binding{}
 		if err := utils.CopyFields(qb, _binding); err != nil {
 			err = utils.APIGenericInternalError(err.Error())
-			return BindingList{Bindings:[]Binding{}}, err
+			return BindingList{Bindings: []Binding{}}, err
 		}
 		bindings = append(bindings, *_binding)
 	}
 
-	return BindingList{Bindings:bindings}, err
+	return BindingList{Bindings: bindings}, err
 
 }
 
@@ -158,22 +158,21 @@ func FindAllBindings(store stores.Store) (BindingList, error) {
 func FindBindingsByServiceTypeAndHost(serviceUUID string, host string, store stores.Store) (BindingList, error) {
 
 	var qBindings []stores.QBinding
-	 var bindings = []Binding{}
+	var bindings = []Binding{}
 	var err error
 
 	if qBindings, err = store.QueryBindings(serviceUUID, host); err != nil {
-		return BindingList{Bindings:[]Binding{}}, err
+		return BindingList{Bindings: []Binding{}}, err
 	}
 
 	for _, qb := range qBindings {
 		_binding := &Binding{}
 		if err := utils.CopyFields(qb, _binding); err != nil {
 			err = utils.APIGenericInternalError(err.Error())
-			return BindingList{Bindings:[]Binding{}}, err
+			return BindingList{Bindings: []Binding{}}, err
 		}
 		bindings = append(bindings, *_binding)
 	}
 
-	return BindingList{Bindings:bindings}, err
+	return BindingList{Bindings: bindings}, err
 }
-

--- a/config.template
+++ b/config.template
@@ -7,5 +7,6 @@
   "certificate_key":"/path/to/key",
   "service_token": "token",
   "supported_auth_types": ["x509", "oidc"],
-  "supported_auth_methods": ["api-key", "x-api-token"]
+  "supported_auth_methods": ["api-key", "x-api-token"],
+  "verify_ssl": true
 }

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ type Config struct {
 	ServiceToken           string   `json:"service_token" required:"true"`
 	SupportedAuthTypes     []string `json:"supported_auth_types" required:"true"`
 	SupportedAuthMethods   []string `json:"supported_auth_methods" required:"true"`
+	VerifySSL              bool     `json:"verify_ssl" `
 }
 
 // ConfigSetUp unmarshals a json file specified by the input parameter into the config object

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,7 +19,7 @@ func (suite *ConfigTestSuite) TestConfigSetUp() {
 	// tests the case of a normal setup
 	cfg2 := &Config{}
 	err2 := cfg2.ConfigSetUp("./configuration-test-files/test-conf.json")
-	expCfg2 := &Config{9000, "test_mongo_host", "test_mongo_db", "/path/to/cas", "/path/to/cert", "/path/to/key", "token", []string{"x509", "oidc"}, []string{"api-key", "x-api-token"}}
+	expCfg2 := &Config{9000, "test_mongo_host", "test_mongo_db", "/path/to/cas", "/path/to/cert", "/path/to/key", "token", []string{"x509", "oidc"}, []string{"api-key", "x-api-token"}, false}
 
 	//tests the case of a malformed json
 	cfg3 := &Config{}
@@ -28,12 +28,12 @@ func (suite *ConfigTestSuite) TestConfigSetUp() {
 	// tests the case of an undeclared field in the json file
 	cfg4 := &Config{}
 	err4 := cfg4.ConfigSetUp("./configuration-test-files/test-conf-missing-field.json")
-	expCfg4 := &Config{0, "test_mongo_host", "test_mongo_db", "/path/to/cas", "/path/to/cert", "/path/to/key", "token", []string{"x509", "oidc"}, []string{"api-key", "x-api-token"}}
+	expCfg4 := &Config{0, "test_mongo_host", "test_mongo_db", "/path/to/cas", "/path/to/cert", "/path/to/key", "token", []string{"x509", "oidc"}, []string{"api-key", "x-api-token"}, false}
 
 	// tests the case of an empty field in the json file
 	cfg5 := &Config{}
 	err5 := cfg5.ConfigSetUp("./configuration-test-files/test-conf-empty-field.json")
-	expCfg5 := &Config{9000, "", "test_mongo_db", "/path/to/cas", "/path/to/cert", "/path/to/key", "token", []string{"x509", "oidc"}, []string{"api-key", "x-api-token"}}
+	expCfg5 := &Config{9000, "", "test_mongo_db", "/path/to/cas", "/path/to/cert", "/path/to/key", "token", []string{"x509", "oidc"}, []string{"api-key", "x-api-token"}, false}
 
 	suite.Equal(cfg2, expCfg2)
 	suite.Equal(cfg3, &Config{})

--- a/config/configuration-test-files/test-conf.json
+++ b/config/configuration-test-files/test-conf.json
@@ -7,5 +7,6 @@
   "certificate_key":"/path/to/key",
   "service_token": "token",
   "supported_auth_types": ["x509", "oidc"],
-  "supported_auth_methods": ["api-key", "x-api-token"]
+  "supported_auth_methods": ["api-key", "x-api-token"],
+  "ssl_verify": false
 }

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -153,6 +153,36 @@ paths:
         500:
           $ref: "#/responses/500"
 
+  /service-types/{Name}/hosts/{Host}:authX509:
+    get:
+      summary: Use an x509 ceritficate to retrieve a token from the given service type
+      description: |
+        Retrieve a token from a service type using an x509.
+        *NOTE You need to provide the request with a valid certificate.
+      parameters:
+        - name: Name
+          in: path
+          description: Name of the service type
+          required: true
+          type: string
+        - name: Host
+          in: path
+          description: Name of the host
+          required: true
+          type: string
+      tags:
+        - Service Types
+      responses:
+        200:
+          description: Returns the token
+          schema:
+            $ref: '#/definitions/TokenResponse'
+        400:
+          $ref: "#/responses/400"
+        404:
+          $ref: '#/responses/404'
+        500:
+          $ref: "#/responses/500"
   /authM:
     get:
       summary: Retrieve information for all authentication methods
@@ -400,6 +430,12 @@ definitions:
       type:
         type: string
         description: api-key, x-api-token (type of auth method)
+
+  TokenResponse:
+    type: object
+    properties:
+      token:
+        type: string
 
   ServiceTypes:
     type: object

--- a/docs/v1/auth_certificate.md
+++ b/docs/v1/auth_certificate.md
@@ -1,0 +1,28 @@
+# Authenticate Using an x509 certificate
+
+## [GET] Authenticate Via x509
+
+This request will use the provided x509 certificate in order to retrieve
+a token from the given service type.
+
+### Example Request
+
+```
+curl -X GET -H "Content-Type: application/json"
+  "https://{URL}/v1/service-types/{Name}/hosts/{host}:authX509" 
+   --cert /path/to/a/cert/file --key /path/to/the/respective/key -k
+```
+
+ ### Response
+ 
+ If the request is successful, the response contains the token that is associated with the provided certificate.
+ 
+ Success Response
+ 
+ `200 CREATED`
+ 
+ ```json
+ {
+    "token": "some-service-type-token"
+ }
+  ```

--- a/handlers/certificate_handlers.go
+++ b/handlers/certificate_handlers.go
@@ -1,0 +1,64 @@
+package handlers
+
+import (
+	"net/http"
+
+	"github.com/ARGOeu/argo-api-authn/bindings"
+	"github.com/ARGOeu/argo-api-authn/config"
+	"github.com/ARGOeu/argo-api-authn/mapX509"
+	"github.com/ARGOeu/argo-api-authn/servicetypes"
+	"github.com/ARGOeu/argo-api-authn/stores"
+	"github.com/ARGOeu/argo-api-authn/utils"
+	"github.com/gorilla/context"
+	"github.com/gorilla/mux"
+)
+
+// AuthViaCert accepts a request containing a certificate and handlers the mapping of a certificate dn to a service type's token
+func AuthViaCert(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+	var ok bool
+	var dataRes = make(map[string]interface{})
+	var binding bindings.Binding
+	var serviceType servicetypes.ServiceType
+
+	//context references
+	store := context.Get(r, "stores").(stores.Store)
+
+	// url vars
+	vars := mux.Vars(r)
+	cfg := context.Get(r, "config").(config.Config)
+
+	if len(r.TLS.PeerCertificates) == 0 {
+		err = &utils.APIError{Message: "No certificate provided", Code: 400, Status: "BAD REQUEST"}
+		utils.RespondError(w, err)
+		return
+	}
+
+	// Find information regarding the requested serviceType
+	if serviceType, err = servicetypes.FindServiceTypeByName(vars["service-type"], store); err != nil {
+		utils.RespondError(w, err)
+		return
+	}
+
+	// check if the provided host is associated with the given serviceType type
+	if ok = serviceType.HasHost(vars["host"]); ok == false {
+		err = utils.APIErrNotFound("Host")
+		utils.RespondError(w, err)
+		return
+	}
+
+	// Find the binding associated with the provided certificate
+	if binding, err = bindings.FindBindingByDN(r.TLS.PeerCertificates[0].Subject.ToRDNSequence().String(), serviceType.UUID, vars["host"], store); err != nil {
+		utils.RespondError(w, err)
+		return
+	}
+
+	// retrieve the resource from the serviceType type
+	if dataRes, err = mapX509.MapX509ToAuthItem(serviceType, binding, vars["host"], store, &cfg); err != nil {
+		utils.RespondError(w, err)
+		return
+	}
+
+	utils.RespondOk(w, 200, dataRes)
+}

--- a/handlers/certificate_handlers_test.go
+++ b/handlers/certificate_handlers_test.go
@@ -1,0 +1,252 @@
+package handlers
+
+import (
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"github.com/ARGOeu/argo-api-authn/auth-methods"
+	"github.com/ARGOeu/argo-api-authn/config"
+	"github.com/ARGOeu/argo-api-authn/stores"
+	log "github.com/Sirupsen/logrus"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type CertificateHandlerSuite struct {
+	suite.Suite
+}
+
+// MockServiceTypeEndpoint mocks the behavior of a service type endpoint and returns a response containing the requested resource
+func MockServiceTypeEndpoint(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(200)
+	w.Write([]byte("{\"token\": \"some-value\"}"))
+}
+
+func AuthViaCertSetUp(reqPath string) (*http.Request, *stores.Mockstore, *config.Config, error) {
+
+	var err error
+	var crt *x509.Certificate
+	var mockstore *stores.Mockstore
+	var cfg *config.Config
+	var req *http.Request
+
+	// create a new certificate from the string literal
+	cert := `-----BEGIN CERTIFICATE-----
+MIIC8jCCAdoCCQCdC824csOlXTANBgkqhkiG9w0BAQsFADA7MQswCQYDVQQGEwJU
+QzELMAkGA1UECAwCVE4xDTALBgNVBAcMBENJVFkxEDAOBgNVBAoMB0NPTVBBTlkw
+HhcNMTgwNjA0MDkwMzA5WhcNMTkwNjA0MDkwMzA5WjA7MQswCQYDVQQGEwJUQzEL
+MAkGA1UECAwCVE4xDTALBgNVBAcMBENJVFkxEDAOBgNVBAoMB0NPTVBBTlkwggEi
+MA0GCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDYahRnf7gxkjz81VX9JjQ/PiB7
+UpGInckBCl5mah/Q3ucr3OvaLLdO4pfmAMTanLxgcTsP7k/yyvZF17IMhQ5wpNzn
+zfLlAswQT6sqkNyJUx1MXI5mjAiDDMpUh0c9CnGaZa/LrnTXmQhsv8uzLDPUYb37
+iHHjP7isYiG+7YE2CpRwHazj0SYba4HAYw8Z1L8Z6kI1gfdIiqI5DFMBdmQlac3P
+YCtYytQd3swCsxf57/M9X+Ct7DVcuPKmR5vv4ONL2YBwtvULX8DA8aApdxIrHCZE
+NRaaCUmMSo4JXHbY5CVP6AXdo3Iz+3v485qtF8lk+XU/fQGNTdgs1hmsTNMRAgMB
+AAEwDQYJKoZIhvcNAQELBQADggEBAAyvW6yVbfCLMxuQ1Nt61OmKA96fTtdTpLuI
+nq9C0XVoFqgrEeobxdH4QbwxduRHWpHEuFskJCBnMbX0d8v63KEN/6I0Ub4niaeP
+nvykp3uoKrRwIZo4OxJFuuuLuUw3aAwkKeqsy5HZsKqi9QscHExRKbcIdlkgxzRW
+IEPEGk7acMlT20ECjc4zbdza8PKQeBeEVLINJVMRGPZIlo/6z6BxSnINQiWBk1WZ
+lXTmJMXGB7/0ECDz2JT1Mbs/q2ijlZywz0xsp+Zdsp1I01wvwqw5M12PHf3buM1w
+SoPmZKiBeb+2OQ2n7+FI8ftkqxWw6zjh651brAoy/0zqLTRPh+c=
+-----END CERTIFICATE-----
+`
+	block, _ := pem.Decode([]byte(cert))
+	if block == nil {
+		panic("failed to parse certificate PEM")
+	}
+
+	if crt, err = x509.ParseCertificate(block.Bytes); err != nil {
+		log.Error(err.Error())
+		return req, mockstore, cfg, err
+	}
+
+	// create a new request and add the created certificate
+	if req, err = http.NewRequest("GET", reqPath, nil); err != nil {
+		return req, mockstore, cfg, err
+	}
+
+	req.TLS = &tls.ConnectionState{}
+	req.TLS.PeerCertificates = append(req.TLS.PeerCertificates, crt)
+
+	// set up the mockstore
+	mockstore = &stores.Mockstore{Server: "localhost", Database: "test_db"}
+	mockstore.SetUp()
+	// append a service type to be used only in auth via cert tests
+	qSt := stores.QServiceType{Name: "s_auth_cert", Hosts: []string{"h1_auth_cert"}, AuthTypes: []string{"x509", "oidc"}, AuthMethod: "mock-api-key", UUID: "uuid_auth_cert", RetrievalField: "token", CreatedOn: "2018-05-05T18:04:05Z"}
+	qSt2 := stores.QServiceType{Name: "s_auth_cert_incorrect", Hosts: []string{"h1_auth_cert"}, AuthTypes: []string{"x509", "oidc"}, AuthMethod: "mock-api-key", UUID: "uuid_auth_cert_incorrect", RetrievalField: "incorrect_field", CreatedOn: "2018-05-05T18:04:05Z"}
+	mockstore.ServiceTypes = append(mockstore.ServiceTypes, qSt, qSt2)
+	// append a binding to be used only in auth via cert tests
+	qB := stores.QBinding{Name: "b_auth_cert", ServiceUUID: "uuid_auth_cert", Host: "h1_auth_cert", DN: "O=COMPANY,L=CITY,ST=TN,C=TC", OIDCToken: "", UniqueKey: "unique_key_1", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	qB2 := stores.QBinding{Name: "b_auth_cert_incorrect", ServiceUUID: "uuid_auth_cert_incorrect", Host: "h1_auth_cert", DN: "O=COMPANY,L=CITY,ST=TN,C=TC", OIDCToken: "", UniqueKey: "unique_key_1", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	mockstore.Bindings = append(mockstore.Bindings, qB, qB2)
+
+	// set up cfg
+	cfg = &config.Config{}
+	_ = cfg.ConfigSetUp("../config/configuration-test-files/test-conf.json")
+
+	// add a mock auth method handler
+	auth_methods.AuthMethodHandlers["mock-api-key"] =
+		func(data map[string]interface{}, store stores.Store, config *config.Config) (*http.Response, error) {
+
+			var req2 *http.Request
+			var err error
+
+			// mock the request that will take place against the given service type
+			if req2, err = http.NewRequest("GET", "http://localhost:8080/some_endpoint", nil); err != nil {
+				log.Error(err.Error())
+			}
+			router := mux.NewRouter().StrictSlash(true)
+			w := httptest.NewRecorder()
+			router.HandleFunc("/some_endpoint", MockServiceTypeEndpoint)
+			router.ServeHTTP(w, req2)
+			return w.Result(), err
+		}
+
+	return req, mockstore, cfg, err
+}
+
+// TestAuthViaCert tests the normal case
+func (suite *CertificateHandlerSuite) TestAuthViaCert() {
+
+	var err error
+	var mockstore *stores.Mockstore
+	var cfg *config.Config
+	var req *http.Request
+
+	expRespJSON := `{
+ "token": "some-value"
+}`
+
+	if req, mockstore, cfg, err = AuthViaCertSetUp("http://localhost:8080/service-types/s_auth_cert/hosts/h1_auth_cert:authX509"); err != nil {
+		log.Error(err.Error())
+	}
+
+	router := mux.NewRouter().StrictSlash(true)
+	w := httptest.NewRecorder()
+	router.HandleFunc("/service-types/{service-type}/hosts/{host}:authX509", WrapConfig(AuthViaCert, mockstore, cfg))
+	router.ServeHTTP(w, req)
+	suite.Equal(200, w.Code)
+	suite.Equal(expRespJSON, w.Body.String())
+}
+
+// TestAuthViaCertIncorrectRetrievalField tests the case where the response from the service type didn't contain the specified retrieval field
+func (suite *CertificateHandlerSuite) TestAuthViaCertIncorrectRetrievalField() {
+
+	var err error
+	var mockstore *stores.Mockstore
+	var cfg *config.Config
+	var req *http.Request
+
+	expRespJSON := `{
+ "error": {
+  "message": "Internal Error: The specified retrieval field: incorrect_field was not found in the response body of the service type",
+  "code": 500,
+  "status": "INTERNAL SERVER ERROR"
+ }
+}`
+
+	if req, mockstore, cfg, err = AuthViaCertSetUp("http://localhost:8080/service-types/s_auth_cert_incorrect/hosts/h1_auth_cert:authX509"); err != nil {
+		log.Error(err.Error())
+	}
+
+	router := mux.NewRouter().StrictSlash(true)
+	w := httptest.NewRecorder()
+	router.HandleFunc("/service-types/{service-type}/hosts/{host}:authX509", WrapConfig(AuthViaCert, mockstore, cfg))
+	router.ServeHTTP(w, req)
+	suite.Equal(500, w.Code)
+	suite.Equal(expRespJSON, w.Body.String())
+}
+
+// TestAuthViaCertUnknownServiceType tests the case where the provided service type is unknown
+func (suite *CertificateHandlerSuite) TestAuthViaCertUnknownServiceType() {
+
+	var err error
+	var mockstore *stores.Mockstore
+	var cfg *config.Config
+	var req *http.Request
+
+	expRespJSON := `{
+ "error": {
+  "message": "ServiceType was not found",
+  "code": 404,
+  "status": "NOT FOUND"
+ }
+}`
+
+	if req, mockstore, cfg, err = AuthViaCertSetUp("http://localhost:8080/service-types/unknown/hosts/h1_auth_cert:authX509"); err != nil {
+		log.Error(err.Error())
+	}
+
+	router := mux.NewRouter().StrictSlash(true)
+	w := httptest.NewRecorder()
+	router.HandleFunc("/service-types/{service-type}/hosts/{host}:authX509", WrapConfig(AuthViaCert, mockstore, cfg))
+	router.ServeHTTP(w, req)
+	suite.Equal(404, w.Code)
+	suite.Equal(expRespJSON, w.Body.String())
+}
+
+// TestAuthViaCertUnknownHost tests the case where the provided host is unknown
+func (suite *CertificateHandlerSuite) TestAuthViaCertUnknownHost() {
+
+	var err error
+	var mockstore *stores.Mockstore
+	var cfg *config.Config
+	var req *http.Request
+
+	expRespJSON := `{
+ "error": {
+  "message": "Host was not found",
+  "code": 404,
+  "status": "NOT FOUND"
+ }
+}`
+
+	if req, mockstore, cfg, err = AuthViaCertSetUp("http://localhost:8080/service-types/s_auth_cert/hosts/unknown:authX509"); err != nil {
+		log.Error(err.Error())
+	}
+
+	router := mux.NewRouter().StrictSlash(true)
+	w := httptest.NewRecorder()
+	router.HandleFunc("/service-types/{service-type}/hosts/{host}:authX509", WrapConfig(AuthViaCert, mockstore, cfg))
+	router.ServeHTTP(w, req)
+	suite.Equal(404, w.Code)
+	suite.Equal(expRespJSON, w.Body.String())
+}
+
+// TestAuthViaCertUnknownDN tests the case where the provided certificate's dn is not assigned to any binding
+func (suite *CertificateHandlerSuite) TestAuthViaCertUnknownDN() {
+
+	var err error
+	var mockstore *stores.Mockstore
+	var cfg *config.Config
+	var req *http.Request
+
+	expRespJSON := `{
+ "error": {
+  "message": "Binding was not found",
+  "code": 404,
+  "status": "NOT FOUND"
+ }
+}`
+
+	if req, mockstore, cfg, err = AuthViaCertSetUp("http://localhost:8080/service-types/s_auth_cert/hosts/h1_auth_cert:authX509"); err != nil {
+		log.Error(err.Error())
+	}
+
+	// empty the mockstore, so no dn will match
+	mockstore.Bindings = []stores.QBinding{}
+
+	router := mux.NewRouter().StrictSlash(true)
+	w := httptest.NewRecorder()
+	router.HandleFunc("/service-types/{service-type}/hosts/{host}:authX509", WrapConfig(AuthViaCert, mockstore, cfg))
+	router.ServeHTTP(w, req)
+	suite.Equal(404, w.Code)
+	suite.Equal(expRespJSON, w.Body.String())
+}
+
+func TestAuthViaCert(t *testing.T) {
+	suite.Run(t, new(CertificateHandlerSuite))
+}

--- a/mapX509/map_x509.go
+++ b/mapX509/map_x509.go
@@ -1,0 +1,57 @@
+package mapX509
+
+import (
+	"github.com/ARGOeu/argo-api-authn/auth-methods"
+	"github.com/ARGOeu/argo-api-authn/bindings"
+	"github.com/ARGOeu/argo-api-authn/servicetypes"
+	"github.com/ARGOeu/argo-api-authn/stores"
+
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/ARGOeu/argo-api-authn/config"
+	"github.com/ARGOeu/argo-api-authn/utils"
+	"net/http"
+)
+
+func MapX509ToAuthItem(serviceType servicetypes.ServiceType, binding bindings.Binding, host string, store stores.Store, config *config.Config) (map[string]interface{}, error) {
+
+	var err error
+	var ok bool
+	var dataRes map[string]interface{}
+	var resp *http.Response
+	var rf interface{}
+
+	// retrieve the auth method handler corresponding to the given serviceType's auth type
+	var data = map[string]interface{}{"service_uuid": serviceType.UUID, "host": host, "unique_key": binding.UniqueKey}
+	authFunc := auth_methods.AuthMethodHandlers[serviceType.AuthMethod]
+	if resp, err = authFunc(data, store, config); err != nil {
+		return dataRes, err
+	}
+
+	if resp.StatusCode >= 400 {
+		// convert the entire response body into a string and include into a genericAPIError
+		buf := bytes.Buffer{}
+		buf.ReadFrom(resp.Body)
+		err = utils.APIGenericInternalError(buf.String())
+		return dataRes, err
+	}
+
+	// get the response from the service type
+	if err = json.NewDecoder(resp.Body).Decode(&dataRes); err != nil {
+		err = utils.APIGenericInternalError(err.Error())
+		return dataRes, err
+	}
+
+	defer resp.Body.Close()
+
+	// check if the retrieval field that we need is present in the response
+	if rf, ok = dataRes[serviceType.RetrievalField]; !ok {
+		err = utils.APIGenericInternalError(fmt.Sprintf(`The specified retrieval field: %v was not found in the response body of the service type`, serviceType.RetrievalField))
+		return dataRes, err
+	}
+
+	// if everything went ok, return the appropriate response field
+	return map[string]interface{}{"token": rf.(string)}, err
+
+}

--- a/mapX509/map_x509_test.go
+++ b/mapX509/map_x509_test.go
@@ -1,0 +1,109 @@
+package mapX509
+
+import (
+	"github.com/ARGOeu/argo-api-authn/auth-methods"
+	"github.com/ARGOeu/argo-api-authn/bindings"
+	"github.com/ARGOeu/argo-api-authn/config"
+	"github.com/ARGOeu/argo-api-authn/servicetypes"
+	"github.com/ARGOeu/argo-api-authn/stores"
+	log "github.com/Sirupsen/logrus"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/suite"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type MapX509Suite struct {
+	suite.Suite
+}
+
+// MockServiceTypeEndpoint mocks the behavior of a service type endpoint and returns a response containing the requested resource
+func MockServiceTypeEndpoint(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(200)
+	w.Write([]byte("{\"token\": \"some-value\"}"))
+}
+
+// MockServiceTypeEndpoint500Error mocks the behavior when the http client produces a 500 error
+func MockServiceTypeEndpoint500Error(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(500)
+	w.Write([]byte("Some internal error"))
+}
+func (suite *MapX509Suite) TestMapX509ToAuthItem() {
+
+	// set up
+	mockstore := &stores.Mockstore{Server: "localhost", Database: "test_db"}
+	mockstore.SetUp()
+
+	cfg := &config.Config{}
+	_ = cfg.ConfigSetUp("../config/configuration-test-files/test-conf.json")
+
+	// append a service type to be used only in auth via cert tests
+	qSt := stores.QServiceType{Name: "s_auth_cert", Hosts: []string{"h1_auth_cert"}, AuthTypes: []string{"x509", "oidc"}, AuthMethod: "mock-api-key", UUID: "uuid_auth_cert", RetrievalField: "token", CreatedOn: "2018-05-05T18:04:05Z"}
+	qSt2 := stores.QServiceType{Name: "s_auth_cert_incorrect", Hosts: []string{"h1_auth_cert"}, AuthTypes: []string{"x509", "oidc"}, AuthMethod: "mock-api-key", UUID: "uuid_auth_cert_incorrect", RetrievalField: "incorrect_field", CreatedOn: "2018-05-05T18:04:05Z"}
+	mockstore.ServiceTypes = append(mockstore.ServiceTypes, qSt, qSt2)
+	// append a binding to be used only in auth via cert tests
+	qB := stores.QBinding{Name: "b_auth_cert", ServiceUUID: "uuid_auth_cert", Host: "h1_auth_cert", DN: "O=COMPANY,L=CITY,ST=TN,C=TC", OIDCToken: "", UniqueKey: "unique_key_1", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	qB2 := stores.QBinding{Name: "b_auth_cert_incorrect", ServiceUUID: "uuid_auth_cert_incorrect", Host: "h1_auth_cert", DN: "O=COMPANY,L=CITY,ST=TN,C=TC", OIDCToken: "", UniqueKey: "unique_key_1", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	mockstore.Bindings = append(mockstore.Bindings, qB, qB2)
+
+	// add a mock auth method handler
+	auth_methods.AuthMethodHandlers["mock-api-key"] =
+		func(data map[string]interface{}, store stores.Store, config *config.Config) (*http.Response, error) {
+
+			var req2 *http.Request
+			var err error
+
+			// mock the request that will take place against the given service type
+			if req2, err = http.NewRequest("GET", "http://localhost:8080/some_endpoint", nil); err != nil {
+				log.Error(err.Error())
+			}
+			router := mux.NewRouter().StrictSlash(true)
+			w := httptest.NewRecorder()
+			router.HandleFunc("/some_endpoint", MockServiceTypeEndpoint)
+			router.ServeHTTP(w, req2)
+			return w.Result(), err
+		}
+
+	serviceType1 := servicetypes.ServiceType{"s1", []string{"host1", "host2", "host3"}, []string{"x509", "oidc"}, "mock-api-key", "uuid1", "token", "2018-05-05T18:04:05Z"}
+	b1 := bindings.Binding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", DN: "dn_ins", OIDCToken: "", UniqueKey: "key"}
+
+	// tests the normal case
+	expM1 := map[string]interface{}{"token": "some-value"}
+	m1, err1 := MapX509ToAuthItem(serviceType1, b1, "host1", mockstore, cfg)
+
+	// tests the case where a 500 error is produced
+	// add a mock auth method handler for the 500 case
+	serviceType2 := servicetypes.ServiceType{"s1", []string{"host1", "host2", "host3"}, []string{"x509", "oidc"}, "mock-api-key-500", "uuid1", "token", "2018-05-05T18:04:05Z"}
+	auth_methods.AuthMethodHandlers["mock-api-key-500"] =
+		func(data map[string]interface{}, store stores.Store, config *config.Config) (*http.Response, error) {
+
+			var req2 *http.Request
+			var err error
+
+			// mock the request that will take place against the given service type
+			if req2, err = http.NewRequest("GET", "http://localhost:8080/some_endpoint", nil); err != nil {
+				log.Error(err.Error())
+			}
+			router := mux.NewRouter().StrictSlash(true)
+			w := httptest.NewRecorder()
+			router.HandleFunc("/some_endpoint", MockServiceTypeEndpoint500Error)
+			router.ServeHTTP(w, req2)
+			return w.Result(), err
+		}
+	_, err2 := MapX509ToAuthItem(serviceType2, b1, "host1", mockstore, cfg)
+
+	// tests the case where the service type's retrieval field can't be found inside the response's body
+	serviceType3 := servicetypes.ServiceType{"s1", []string{"host1", "host2", "host3"}, []string{"x509", "oidc"}, "mock-api-key", "uuid1", "unknown", "2018-05-05T18:04:05Z"}
+	_, err3 := MapX509ToAuthItem(serviceType3, b1, "host1", mockstore, cfg)
+
+	suite.Equal(expM1, m1)
+
+	suite.Nil(err1)
+	suite.Equal("Internal Error: Some internal error", err2.Error())
+	suite.Equal("Internal Error: The specified retrieval field: unknown was not found in the response body of the service type", err3.Error())
+}
+
+func TestMapX509Suite(t *testing.T) {
+	suite.Run(t, new(MapX509Suite))
+}

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -24,6 +24,7 @@ type APIRoute struct {
 	Method  string           // GET, POST, PUT string literals
 	Path    string           // API call path with urlVars included
 	Handler http.HandlerFunc // Handler Function to be used
+	Auth    bool             // whether or not it should use the auth handler
 }
 
 // NewRouting creates a new routing object including mux.Router and routes definitions
@@ -45,7 +46,10 @@ func NewRouting(routes []APIRoute, store stores.Store, config *config.Config) *A
 
 		handler = handlers.WrapLog(handler, route.Name)
 
-		handler = handlers.WrapAuth(handler, store)
+		//  skip the auth handler for the requests that don't require authorization
+		if route.Auth {
+			handler = handlers.WrapAuth(handler, store)
+		}
 
 		handler = handlers.WrapConfig(handler, store, config)
 
@@ -62,15 +66,15 @@ func NewRouting(routes []APIRoute, store stores.Store, config *config.Config) *A
 }
 
 var ApiRoutes = []APIRoute{
-	{"serviceTypes:create", "POST", "/service-types", handlers.ServiceTypeCreate},
-	{"serviceTypes:ListOne", "GET", "/service-types/{service-type}", handlers.ServiceTypesListOne},
-	{"serviceType:ListAll", "GET", "/service-types", handlers.ServiceTypeListAll},
-	{"authMethod:ListOne", "GET", "/service-types/{service-type}/hosts/{host}/authM", handlers.AuthMethodListOne},
-	{"bindings:ListAllByServiceTypeAndHost", "GET", "/service-types/{service-type}/hosts/{host}/bindings", handlers.BindingListAllByServiceTypeAndHost},
-	{"bindings:ListOneByDN", "GET", "/service-types/{service-type}/hosts/{host}/bindings/{dn}", handlers.BindingListOneByDN},
-	{"authMethod:ListAll", "GET", "/authM", handlers.AuthMethodListAll},
-	{"authMethod:Create", "POST", "/authM", handlers.AuthMethodCreate},
-	{"bindings:create", "POST", "/bindings", handlers.BindingCreate},
-	{"bindings:ListAll", "GET", "/bindings", handlers.BindingListAll},
-	//{"auth:dn", "GET", "/auth/{service}/{host}/x509", handlers.AuthViaCert},
+	{"serviceTypes:create", "POST", "/service-types", handlers.ServiceTypeCreate, true},
+	{"serviceTypes:ListOne", "GET", "/service-types/{service-type}", handlers.ServiceTypesListOne, true},
+	{"serviceType:ListAll", "GET", "/service-types", handlers.ServiceTypeListAll, true},
+	{"authMethod:ListOne", "GET", "/service-types/{service-type}/hosts/{host}/authM", handlers.AuthMethodListOne, true},
+	{"bindings:ListAllByServiceTypeAndHost", "GET", "/service-types/{service-type}/hosts/{host}/bindings", handlers.BindingListAllByServiceTypeAndHost, true},
+	{"bindings:ListOneByDN", "GET", "/service-types/{service-type}/hosts/{host}/bindings/{dn}", handlers.BindingListOneByDN, true},
+	{"authMethod:ListAll", "GET", "/authM", handlers.AuthMethodListAll, true},
+	{"authMethod:Create", "POST", "/authM", handlers.AuthMethodCreate, true},
+	{"bindings:create", "POST", "/bindings", handlers.BindingCreate, true},
+	{"bindings:ListAll", "GET", "/bindings", handlers.BindingListAll, true},
+	{"auth:dn", "GET", "/service-types/{service-type}/hosts/{host}:authX509", handlers.AuthViaCert, false},
 }

--- a/servicetypes/service_type.go
+++ b/servicetypes/service_type.go
@@ -131,19 +131,19 @@ func FindAllServiceTypes(store stores.Store) (ServiceList, error) {
 	var err error
 
 	if qServices, err = store.QueryServiceTypes(""); err != nil {
-		return ServiceList{ServiceTypes:services}, err
+		return ServiceList{ServiceTypes: services}, err
 	}
 
 	for _, qs := range qServices {
 		_service := &ServiceType{}
 		if err := utils.CopyFields(qs, _service); err != nil {
 			err = utils.APIGenericInternalError(err.Error())
-			return ServiceList{ServiceTypes:services}, err
+			return ServiceList{ServiceTypes: services}, err
 		}
 		services = append(services, *_service)
 	}
 
-	return ServiceList{ServiceTypes:services}, err
+	return ServiceList{ServiceTypes: services}, err
 
 }
 

--- a/servicetypes/service_type_test.go
+++ b/servicetypes/service_type_test.go
@@ -131,7 +131,7 @@ func (suite *ServiceTestSuite) TestFindAllServiceTypes() {
 	serAll1, err1 := FindAllServiceTypes(mockstore)
 
 	// normal case outcome - empty list
-	var empServ = ServiceList{ServiceTypes:[]ServiceType{}}
+	var empServ = ServiceList{ServiceTypes: []ServiceType{}}
 	mockstore.ServiceTypes = []stores.QServiceType{}
 	serAll2, err2 := FindAllServiceTypes(mockstore)
 


### PR DESCRIPTION
Provided a x509 certificate with the request, it will map the dn to a token for the specified service type