### PR TITLE
ARGO-1312 Add utils method that sets a value to field given its name

### DIFF
--- a/utils/utils.go
+++ b/utils/utils.go
@@ -70,6 +70,45 @@ func GetFieldValueByName(instance interface{}, fieldName string) (interface{}, e
 	return flv.Interface(), nil
 }
 
+// SetFieldValueByName assigns a value to the specified field of the given interface
+func SetFieldValueByName(instance interface{}, fieldName string, value interface{}) error {
+
+	var v reflect.Value
+	var vf reflect.Value
+	var flv reflect.Value
+
+	// Check if the field's name is capitalized to make sure its exported otherwise .Interface() will panic
+	if !IsCapitalized(fieldName) {
+		return errors.New("you are trying to access an unexported field")
+	}
+
+	v = reflect.ValueOf(instance)
+	vf = reflect.ValueOf(value)
+
+	// it requires a pointer to a struct so its fields are addressable in order to be set through the Set() method
+	if v.Kind() != reflect.Ptr {
+		return errors.New("SetFieldValueByName needs a pointer to a struct")
+	}
+
+	flv = v.Elem().FieldByName(fieldName)
+
+	// check if the field exists
+	zeroReflectValue := reflect.Value{}
+	if reflect.DeepEqual(flv, zeroReflectValue) {
+		return errors.New("Field: " + fieldName + " has not been declared.")
+	}
+
+	// check if the field and value types match
+	if flv.Type() != vf.Type() {
+		return errors.New("type miss match between field and value")
+	}
+
+	// if everything is ok assign the value
+	flv.Set(vf)
+
+	return nil
+}
+
 // StructToMap converts a non nil struct to a map of map[string]interface{}
 func StructToMap(instance interface{}) map[string]interface{} {
 

--- a/utils/utils_test.go
+++ b/utils/utils_test.go
@@ -96,6 +96,41 @@ func (suite *UtilsTestSuite) TestGetFieldByName() {
 
 }
 
+func (suite *UtilsTestSuite) TestSetFieldValueByName() {
+
+	tt := TestStruct{}
+
+	// normal case
+	err1 := SetFieldValueByName(&tt, "Field1", "value")
+
+	// non pointer argument
+	err2 := SetFieldValueByName(tt, "Field1", "value")
+
+	// non exported field
+	err3 := SetFieldValueByName(&tt, "field1", "value")
+
+	// type miss match between field and value
+	err4 := SetFieldValueByName(&tt, "Field1", 90)
+
+	// unknown field
+	err5 := SetFieldValueByName(&tt, "Unknown", "value")
+
+	// normal case - pointer value
+	s := "value"
+	err6 := SetFieldValueByName(&tt, "Field5", &s)
+
+	suite.Equal("value",tt.Field1)
+	suite.Equal("value", *(tt.Field5))
+
+	suite.Nil(err1)
+	suite.Equal("SetFieldValueByName needs a pointer to a struct", err2.Error())
+	suite.Equal("you are trying to access an unexported field", err3.Error())
+	suite.Equal("type miss match between field and value", err4.Error())
+	suite.Equal("Field: Unknown has not been declared.", err5.Error())
+	suite.Nil(err6)
+
+}
+
 func (suite *UtilsTestSuite) TestStructToMap() {
 
 	//tests the normal case with unexported field


### PR DESCRIPTION
For later use in the project we will need a generic Setter method in order to avoid populating our interfaces with setter methods.

The problem is that we need our fields to be Exported in the structs that implement an interface so we can use the json marshal/unmarshal but we will also need setters to manipulate fields.Since we pass around interfaces and not concrete types, we will ahve to polute our interfaces with setters.