### PR TITLE
ARGO-1740 Change binding structure to be more generic

### DIFF
--- a/auth/certificate_test.go
+++ b/auth/certificate_test.go
@@ -88,7 +88,7 @@ SoPmZKiBeb+2OQ2n7+FI8ftkqxWw6zjh651brAoy/0zqLTRPh+c=
 	err1 := CertHasExpired(crt)
 
 	// expired case
-	crt.NotAfter = time.Now().AddDate(0,0,-1)
+	crt.NotAfter = time.Now().AddDate(0, 0, -1)
 	err2 := CertHasExpired(crt)
 
 	//  not active yet

--- a/bindings/binding_test.go
+++ b/bindings/binding_test.go
@@ -16,47 +16,50 @@ func (suite *BindingTestSuite) TestCreateBinding() {
 	mockstore.SetUp()
 
 	// test the normal case
-	b1 := Binding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", DN: "dn_ins", OIDCToken: "", UniqueKey: "key"}
+	b1 := Binding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", AuthIdentifier: "dn_ins", UniqueKey: "key", AuthType: "x509"}
 	_, err1 := CreateBinding(b1, mockstore)
-	res1, _ := mockstore.QueryBindingsByDN("dn_ins", "uuid1", "host1")
+	res1, _ := mockstore.QueryBindingsByAuthID("dn_ins", "uuid1", "host1", "x509")
 
 	// tests the case of missing field name
-	b2 := Binding{ServiceUUID: "uuid1", Host: "host1", DN: "dn_ins", OIDCToken: "", UniqueKey: "key"}
+	b2 := Binding{ServiceUUID: "uuid1", Host: "host1", AuthIdentifier: "dn_ins", UniqueKey: "key", AuthType: "x509"}
 	_, err2 := CreateBinding(b2, mockstore)
 
 	// tests the case with missing field serviceUUID
-	b3 := Binding{Name: "bins", Host: "host1", DN: "dn_ins", OIDCToken: "", UniqueKey: "key"}
+	b3 := Binding{Name: "bins", Host: "host1", AuthIdentifier: "dn_ins", UniqueKey: "key", AuthType: "x509"}
 	_, err3 := CreateBinding(b3, mockstore)
 
 	// tests the case with missing field host
-	b4 := Binding{Name: "bins", ServiceUUID: "uuid1", DN: "dn_ins", OIDCToken: "", UniqueKey: "key"}
+	b4 := Binding{Name: "bins", ServiceUUID: "uuid1", AuthIdentifier: "dn_ins", UniqueKey: "key", AuthType: "x509"}
 	_, err4 := CreateBinding(b4, mockstore)
 
 	// tests the case with missing field uniquekey
-	b5 := Binding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", DN: "dn_ins", OIDCToken: ""}
+	b5 := Binding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", AuthIdentifier: "dn_ins"}
 	_, err5 := CreateBinding(b5, mockstore)
 
 	// tests the case with missing field dn and oidctoken
-	b6 := Binding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", UniqueKey: "key"}
+	b6 := Binding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", UniqueKey: "key", AuthType: "x509"}
 	_, err6 := CreateBinding(b6, mockstore)
 
 	// tests the case with unknown service uuid
-	b7 := Binding{Name: "bins", ServiceUUID: "unknown", Host: "host1", DN: "dn_ins", OIDCToken: "", UniqueKey: "key"}
+	b7 := Binding{Name: "bins", ServiceUUID: "unknown", Host: "host1", AuthIdentifier: "dn_ins", UniqueKey: "key", AuthType: "x509"}
 	_, err7 := CreateBinding(b7, mockstore)
 
 	// tests the case with unknown host
-	b8 := Binding{Name: "bins", ServiceUUID: "uuid1", Host: "unknown", DN: "dn_ins", OIDCToken: "", UniqueKey: "key"}
+	b8 := Binding{Name: "bins", ServiceUUID: "uuid1", Host: "unknown", AuthIdentifier: "dn_ins", UniqueKey: "key", AuthType: "x509"}
 	_, err8 := CreateBinding(b8, mockstore)
 
 	// tests the case where a binding with the given dn already exists
-	b9 := Binding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "key"}
+	b9 := Binding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", AuthIdentifier: "test_dn_1", UniqueKey: "key", AuthType: "x509"}
 	_, err9 := CreateBinding(b9, mockstore)
+
+	// tests the case where a binding's auth type is not supported by is service type
+	b10 := Binding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", AuthIdentifier: "test_auth", UniqueKey: "key", AuthType: "unknown"}
+	_, err10 := CreateBinding(b10, mockstore)
 
 	suite.Equal(b1.Name, res1[0].Name)
 	suite.Equal(b1.ServiceUUID, res1[0].ServiceUUID)
 	suite.Equal(b1.Host, res1[0].Host)
 	suite.NotEqual("", res1[0].UUID)
-	suite.Equal(b1.OIDCToken, res1[0].OIDCToken)
 	suite.Equal(b1.UniqueKey, res1[0].UniqueKey)
 
 	suite.Nil(err1)
@@ -64,10 +67,11 @@ func (suite *BindingTestSuite) TestCreateBinding() {
 	suite.Equal("binding object contains empty fields. empty value for field: service_uuid", err3.Error())
 	suite.Equal("binding object contains empty fields. empty value for field: host", err4.Error())
 	suite.Equal("binding object contains empty fields. empty value for field: unique_key", err5.Error())
-	suite.Equal("binding object contains empty fields. Both DN and OIDC Token fields are empty", err6.Error())
+	suite.Equal("binding object contains empty fields. empty value for field: auth_identifier", err6.Error())
 	suite.Equal("Service-type was not found", err7.Error())
 	suite.Equal("Host was not found", err8.Error())
-	suite.Equal("binding object with dn: test_dn_1 already exists", err9.Error())
+	suite.Equal("binding object with auth_identifier: test_dn_1 already exists", err9.Error())
+	suite.Equal("Auth type: unknown is not yet supported.Supported:[x509 oidc]", err10.Error())
 
 }
 
@@ -77,26 +81,27 @@ func (suite *BindingTestSuite) TestFindBindingByDN() {
 	mockstore.SetUp()
 
 	// tests the normal case
-	expBinding1 := Binding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "unique_key_1"}
-	b1, err1 := FindBindingByDN("test_dn_1", "uuid1", "host1", mockstore)
+	expBinding1 := Binding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509"}
+	b1, err1 := FindBindingByAuthID("test_dn_1", "uuid1", "host1", "x509", mockstore)
 
 	suite.Equal(expBinding1.Name, b1.Name)
 	suite.Equal(expBinding1.ServiceUUID, b1.ServiceUUID)
 	suite.Equal(expBinding1.Host, b1.Host)
-	suite.Equal(expBinding1.DN, b1.DN)
+	suite.Equal(expBinding1.AuthIdentifier, b1.AuthIdentifier)
 	suite.Equal(expBinding1.UniqueKey, b1.UniqueKey)
+	suite.Equal(expBinding1.AuthType, b1.AuthType)
 
 	// tests the not found case
-	_, err2 := FindBindingByDN("unknown", "unknown", "unknown", mockstore)
+	_, err2 := FindBindingByAuthID("unknown", "unknown", "unknown", "x509", mockstore)
 
 	// tests the case of more than 2 bindigs with the same dn exist under the same host and service
 	// append one more binding , same to an existing
-	mockstore.Bindings = append(mockstore.Bindings, stores.QBinding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "unique_key_1"})
-	_, err3 := FindBindingByDN("test_dn_1", "uuid1", "host1", mockstore)
+	mockstore.Bindings = append(mockstore.Bindings, stores.QBinding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509"})
+	_, err3 := FindBindingByAuthID("test_dn_1", "uuid1", "host1", "x509", mockstore)
 
 	suite.Nil(err1)
 	suite.Equal("Binding was not found", err2.Error())
-	suite.Equal("Database Error: More than 1 bindings found under the service type: uuid1 and host: host1 using the same DN: test_dn_1", err3.Error())
+	suite.Equal("Database Error: More than 1 bindings found under the service type: uuid1 and host: host1 using the same AuthIdentifier: test_dn_1", err3.Error())
 
 }
 
@@ -106,22 +111,23 @@ func (suite *BindingTestSuite) TestFindBindingByUUID() {
 	mockstore.SetUp()
 
 	// tests the normal case
-	expBinding1 := Binding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "unique_key_1"}
+	expBinding1 := Binding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509"}
 	b1, err1 := FindBindingByUUID("b_uuid1", mockstore)
 
 	suite.Equal(expBinding1.Name, b1.Name)
 	suite.Equal(expBinding1.ServiceUUID, b1.ServiceUUID)
 	suite.Equal(expBinding1.Host, b1.Host)
 	suite.Equal(expBinding1.UUID, b1.UUID)
-	suite.Equal(expBinding1.DN, b1.DN)
+	suite.Equal(expBinding1.AuthIdentifier, b1.AuthIdentifier)
 	suite.Equal(expBinding1.UniqueKey, b1.UniqueKey)
+	suite.Equal(expBinding1.AuthType, b1.AuthType)
 
 	// tests the not found case
 	_, err2 := FindBindingByUUID("unknown", mockstore)
 
 	// tests the case of more than 2 bindigs with the same dn exist under the same host and service
 	// append one more binding , same to an existing
-	mockstore.Bindings = append(mockstore.Bindings, stores.QBinding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "unique_key_1"})
+	mockstore.Bindings = append(mockstore.Bindings, stores.QBinding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1"})
 	_, err3 := FindBindingByUUID("b_uuid1", mockstore)
 
 	suite.Nil(err1)
@@ -137,9 +143,9 @@ func (suite *BindingTestSuite) TestFindAllBindings() {
 
 	// tests the normal case
 	expectedBL := BindingList{}
-	binding1 := Binding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "unique_key_1", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
-	binding2 := Binding{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", DN: "test_dn_2", OIDCToken: "", UniqueKey: "unique_key_2", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
-	binding3 := Binding{Name: "b3", ServiceUUID: "uuid1", Host: "host2", UUID: "b_uuid3", DN: "test_dn_3", OIDCToken: "", UniqueKey: "unique_key_3", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	binding1 := Binding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	binding2 := Binding{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", AuthIdentifier: "test_dn_2", UniqueKey: "unique_key_2", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	binding3 := Binding{Name: "b3", ServiceUUID: "uuid1", Host: "host2", UUID: "b_uuid3", AuthIdentifier: "test_dn_3", UniqueKey: "unique_key_3", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
 	expectedBL.Bindings = append(expectedBL.Bindings, binding1, binding2, binding3)
 
 	bl, err := FindAllBindings(mockstore)
@@ -162,8 +168,8 @@ func (suite *BindingTestSuite) TestFindBindingsByServiceTypeAndHost() {
 
 	// tests the normal case
 	expectedBL := BindingList{}
-	binding1 := Binding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "unique_key_1", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
-	binding2 := Binding{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", DN: "test_dn_2", OIDCToken: "", UniqueKey: "unique_key_2", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	binding1 := Binding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	binding2 := Binding{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", AuthIdentifier: "test_dn_2", UniqueKey: "unique_key_2", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
 	expectedBL.Bindings = append(expectedBL.Bindings, binding1, binding2)
 
 	b1, err1 := FindBindingsByServiceTypeAndHost("uuid1", "host1", mockstore)
@@ -185,52 +191,55 @@ func (suite *BindingTestSuite) TestUpdateBinding() {
 	mockstore.SetUp()
 
 	// insert a binding
-	b1_ins := stores.QBinding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", DN: "dn_ins", OIDCToken: "", UniqueKey: "key"}
+	b1_ins := stores.QBinding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", AuthIdentifier: "dn_ins", UniqueKey: "key", AuthType: "x509"}
 	mockstore.Bindings = append(mockstore.Bindings, b1_ins)
 
-	b1 := Binding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", DN: "dn_ins", OIDCToken: "", UniqueKey: "key"}
+	b1 := Binding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", AuthIdentifier: "dn_ins", UniqueKey: "key", AuthType: "x509"}
 
 	// test the normal case
-	b1_upd := TempUpdateBinding{Name: "bins_tmp", ServiceUUID: "uuid1", Host: "host1", DN: "dn_ins_tmp", OIDCToken: "", UniqueKey: "key_tmp"}
+	b1_upd := TempUpdateBinding{Name: "bins_tmp", ServiceUUID: "uuid1", Host: "host1", AuthIdentifier: "dn_ins_tmp", UniqueKey: "key_tmp", AuthType: "x509"}
 	_, err1 := UpdateBinding(b1, b1_upd, mockstore)
-	res1, _ := mockstore.QueryBindingsByDN("dn_ins_tmp", "uuid1", "host1")
+	res1, _ := mockstore.QueryBindingsByAuthID("dn_ins_tmp", "uuid1", "host1", "x509")
 
 	// tests the case of providing an empty name
-	b2 := TempUpdateBinding{Name: "", ServiceUUID: "uuid1", Host: "host1", DN: "dn_ins", OIDCToken: "", UniqueKey: "key"}
+	b2 := TempUpdateBinding{Name: "", ServiceUUID: "uuid1", Host: "host1", AuthIdentifier: "dn_ins", UniqueKey: "key", AuthType: "x509"}
 	_, err2 := UpdateBinding(b1, b2, mockstore)
 
 	// tests the case of providing an empty serviceUUID
-	b3 := TempUpdateBinding{Name: "bins", ServiceUUID: "", Host: "host1", DN: "dn_ins", OIDCToken: "", UniqueKey: "key"}
+	b3 := TempUpdateBinding{Name: "bins", ServiceUUID: "", Host: "host1", AuthIdentifier: "dn_ins", UniqueKey: "key", AuthType: "x509"}
 	_, err3 := UpdateBinding(b1, b3, mockstore)
 
 	// tests the case of providing an empty host
-	b4 := TempUpdateBinding{Name: "bins", ServiceUUID: "uuid1", Host: "", DN: "dn_ins", OIDCToken: "", UniqueKey: "key"}
+	b4 := TempUpdateBinding{Name: "bins", ServiceUUID: "uuid1", Host: "", AuthIdentifier: "dn_ins", UniqueKey: "key", AuthType: "x509"}
 	_, err4 := UpdateBinding(b1, b4, mockstore)
 
 	// tests the case of providing an empty unique key
-	b5 := TempUpdateBinding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", DN: "dn_ins", OIDCToken: "", UniqueKey: ""}
+	b5 := TempUpdateBinding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", AuthIdentifier: "dn_ins", UniqueKey: ""}
 	_, err5 := UpdateBinding(b1, b5, mockstore)
 
-	// tests the case with missing field dn and oidctoken
-	b6 := TempUpdateBinding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", UniqueKey: "key", DN: "", OIDCToken: ""}
+	// tests the case with missing auth id field
+	b6 := TempUpdateBinding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", UniqueKey: "key", AuthIdentifier: ""}
 	_, err6 := UpdateBinding(b1, b6, mockstore)
 
 	// tests the case with unknown service uuid
-	b7 := TempUpdateBinding{Name: "bins", ServiceUUID: "unknown", Host: "host1", DN: "dn_ins", OIDCToken: "", UniqueKey: "key"}
+	b7 := TempUpdateBinding{Name: "bins", ServiceUUID: "unknown", Host: "host1", AuthIdentifier: "dn_ins", UniqueKey: "key", AuthType: "x509"}
 	_, err7 := UpdateBinding(b1, b7, mockstore)
 
 	// tests the case with unknown host
-	b8 := TempUpdateBinding{Name: "bins", ServiceUUID: "uuid1", Host: "unknown", DN: "dn_ins", OIDCToken: "", UniqueKey: "key"}
+	b8 := TempUpdateBinding{Name: "bins", ServiceUUID: "uuid1", Host: "unknown", AuthIdentifier: "dn_ins", UniqueKey: "key", AuthType: "x509"}
 	_, err8 := UpdateBinding(b1, b8, mockstore)
 
 	// tests the case where a binding with the given dn already exists
-	b9 := TempUpdateBinding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "key"}
+	b9 := TempUpdateBinding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", AuthIdentifier: "test_dn_1", UniqueKey: "key", AuthType: "x509"}
 	_, err9 := UpdateBinding(b1, b9, mockstore)
+
+	// tests the case with missing auth id field
+	b10 := TempUpdateBinding{Name: "bins", ServiceUUID: "uuid1", Host: "host1", UniqueKey: "key", AuthIdentifier: "test_dn_1", AuthType: ""}
+	_, err10 := UpdateBinding(b1, b10, mockstore)
 
 	suite.Equal(b1_upd.Name, res1[0].Name)
 	suite.Equal(b1_upd.ServiceUUID, res1[0].ServiceUUID)
 	suite.Equal(b1_upd.Host, res1[0].Host)
-	suite.Equal(b1_upd.OIDCToken, res1[0].OIDCToken)
 	suite.Equal(b1_upd.UniqueKey, res1[0].UniqueKey)
 
 	suite.Nil(err1)
@@ -238,10 +247,12 @@ func (suite *BindingTestSuite) TestUpdateBinding() {
 	suite.Equal("binding object contains empty fields. empty value for field: service_uuid", err3.Error())
 	suite.Equal("binding object contains empty fields. empty value for field: host", err4.Error())
 	suite.Equal("binding object contains empty fields. empty value for field: unique_key", err5.Error())
-	suite.Equal("binding object contains empty fields. Both DN and OIDC Token fields are empty", err6.Error())
+	suite.Equal("binding object contains empty fields. empty value for field: auth_identifier", err6.Error())
 	suite.Equal("Service-type was not found", err7.Error())
 	suite.Equal("Host was not found", err8.Error())
-	suite.Equal("binding object with dn: test_dn_1 already exists", err9.Error())
+	suite.Equal("binding object with auth_identifier: test_dn_1 already exists", err9.Error())
+	suite.Equal("binding object contains empty fields. empty value for field: auth_type", err10.Error())
+
 }
 
 func (suite *BindingTestSuite) TestDeleteBinding() {
@@ -249,12 +260,12 @@ func (suite *BindingTestSuite) TestDeleteBinding() {
 	mockstore := &stores.Mockstore{Server: "localhost", Database: "test_db"}
 	mockstore.SetUp()
 
-	b_del := Binding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "unique_key_1", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	b_del := Binding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
 	err1 := DeleteBinding(b_del, mockstore)
 
 	// tests the normal case - query the store to find if the deleted binding is indeed missing
 	expectedBL := BindingList{}
-	binding1 := Binding{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", DN: "test_dn_2", OIDCToken: "", UniqueKey: "unique_key_2", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	binding1 := Binding{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", AuthIdentifier: "test_dn_2", UniqueKey: "unique_key_2", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
 	expectedBL.Bindings = append(expectedBL.Bindings, binding1)
 
 	bL1, _ := FindBindingsByServiceTypeAndHost("uuid1", "host1", mockstore)

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -442,9 +442,9 @@ paths:
                 type: string
               host:
                 type: string
-              dn:
+              auth_identifier:
                 type: string
-              oidc_token:
+              auth_type:
                 type: string
               unique_key:
                 type: string
@@ -545,9 +545,9 @@ paths:
                 type: string
               host:
                 type: string
-              dn:
+              auth_identifier:
                 type: string
-              oidc_token:
+              auth_type:
                 type: string
               unique_key:
                 type: string
@@ -657,14 +657,15 @@ definitions:
       uuid:
         type: string
         description: binding's uuid
-      dn:
+      auth_identifier:
         type: string
-        description: the dn of the certificate
-      oidc_token:
-        type: string
+        description: the authentication identifier that will be used to perform the mapping(e.g. a cert's DN)
       unique_key:
         type: string
         description: contains the resource to be used to authenticate against the assosciated service type
+      auth_type:
+        type: string
+        description: the type of authentication that this binding represets(e.g. x509)
       created_on:
         type: string
       last_auth:

--- a/docs/v1/docs/api_bindings.md
+++ b/docs/v1/docs/api_bindings.md
@@ -8,7 +8,7 @@ For example, a service type's "user", requires an api token to authenticate to i
  
 remembered by the "user" or retrieved using some form of credentials.
  
- A binding will hold additional information like a DN or an OIDC Token, that can be used to retrieve the required api token.
+ A binding will hold additional information like a DN or an OIDC Token(in the auth_identifier field), that can be used to retrieve the required api token.
  
  A binding is associated with the uuid of a service type,the host on which this service type runs on,
  
@@ -37,8 +37,8 @@ curl -X POST -H "Content-Type: application/json"
 	"name": "b1",
 	"service_uuid": "b61030d9-bef3-4768-9a03-7b1ff36e8af4cc",
 	"host": "host1",
-	"dn":"dn",
-	"oidc_token": "token",
+	"auth_identifier":"dn",
+	"auth_type": "x509",
 	"unique_key": "key"
 }
 ```
@@ -57,9 +57,9 @@ Success Response
      "service_uuid": "b61030d9-bef3-4768-9a03-7b1ff36e8af4cc",
      "host": "host1",
      "uuid": "p61020d9-bef3-4768-9a03-331ff36e8af4cc",
-     "dn": "host1",
-     "oidc_token": "token",
+     "auth_identifier": "dn",
      "unique_key": "key",
+     "auth_type": "x509",
      "created_on": "2018-05-24T09:58:17Z"
  }
  
@@ -95,8 +95,9 @@ If the request is successful, the response contains all the bindings in the serv
                   "service_uuid": "uuid1",
                   "host": "host1",
                   "uuid": "p61020d9-bef3-4768-9a03-331ff36e8af4cc",
-                  "oidc_token": "testdn",
+                  "auth_identifier": "testdn",
                   "unique_key": "key",
+                  "auth_type": "x509",
                   "created_on": "2018-05-23T09:25:25Z",
                   "last_auth": "2018-05-23T09:25:25Z"
               },
@@ -105,8 +106,9 @@ If the request is successful, the response contains all the bindings in the serv
                   "service_uuid": "uuid1",
                   "host": "host1",
                   "uuid": "p61020d9-bef3-4768-9a03-331ff36e8af4rr",
-                  "oidc_token": "testdn",
+                  "auth_identifier": "testdn",
                   "unique_key": "key",
+                  "auth_type": "x509",                
                   "created_on": "2018-05-23T09:25:43Z",
                   "last_auth": "2018-05-23T09:25:25Z"
               }
@@ -143,9 +145,10 @@ If the request is successful, the response contains all the bindings under the g
                   "name": "testb",
                   "service_uuid": "uuid1",
                   "host": "host1",
-                  "oidc_token": "testdn",
+                  "auth_identifier": "testdn",
                   "uuid": "p61020d9-bef3-4768-9a03-331ff36e8af4cc",
                   "unique_key": "key",
+                  "auth_type": "x509",                
                   "created_on": "2018-05-23T09:25:25Z",
                   "last_auth": "2018-05-23T09:25:25Z"
               },
@@ -154,8 +157,9 @@ If the request is successful, the response contains all the bindings under the g
                   "service_uuid": "uuid1",
                   "host": "host1",
                   "uuid": "p61020d9-bef3-4768-9a03-331ff36e8af4rr",
-                  "oidc_token": "testdn",
+                  "auth_identifier": "testdn",
                   "unique_key": "key",
+                  "auth_type": "x509",                
                   "created_on": "2018-05-23T09:25:43Z",
                   "last_auth": "2018-05-23T09:25:25Z"
               }
@@ -191,8 +195,9 @@ If the request is successful, the response contains the binding associated with 
       "service_uuid": "uuid1",
       "host": "host1",
       "uuid": "p61020d9-bef3-4768-9a03-331ff36e8af4cc",
-      "oidc_token": "testdn",
+      "auth_identifier": "testdn",
       "unique_key": "key",
+      "auth_type": "x509",                
       "created_on": "2018-05-23T09:25:25Z",
       "last_auth": "2018-05-23T09:25:25Z"   
   }
@@ -238,9 +243,9 @@ If the request is successful, the response contains the updated binding.
      "service_uuid": "b61030d9-bef3-4768-9a03-7b1ff36e8af4cc",
      "host": "host1",
      "uuid": "p61020d9-bef3-4768-9a03-331ff36e8af4cc",
-     "dn": "host1",
-     "oidc_token": "token",
+     "auth_identifier": "host1",
      "unique_key": "key",
+     "auth_type": "x509",                
      "created_on": "2018-05-24T09:58:17Z"
  }
 ```

--- a/handlers/binding_handlers.go
+++ b/handlers/binding_handlers.go
@@ -88,8 +88,8 @@ func BindingListAllByServiceTypeAndHost(w http.ResponseWriter, r *http.Request) 
 
 }
 
-// BindingListOneByDN finds and returns information about a binding, using its dn, service type and host
-func BindingListOneByDN(w http.ResponseWriter, r *http.Request) {
+// BindingListOneByAuthID finds and returns information about a binding, using its auth identifier, service type and host
+func BindingListOneByAuthID(w http.ResponseWriter, r *http.Request) {
 
 	var err error
 	var ok bool
@@ -115,7 +115,7 @@ func BindingListOneByDN(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if binding, err = bindings.FindBindingByDN(vars["dn"], serviceType.UUID, vars["host"], store); err != nil {
+	if binding, err = bindings.FindBindingByAuthID(vars["dn"], serviceType.UUID, vars["host"], "x509", store); err != nil {
 		utils.RespondError(w, err)
 		return
 	}

--- a/handlers/certificate_handlers.go
+++ b/handlers/certificate_handlers.go
@@ -75,7 +75,7 @@ func AuthViaCert(w http.ResponseWriter, r *http.Request) {
 
 	LOGGER.Infof("Certificate request: %v for Service-Type: %v and  Host: %v", rdnSequence, serviceType.Name, vars["host"])
 
-	if binding, err = bindings.FindBindingByDN(rdnSequence, serviceType.UUID, vars["host"], store); err != nil {
+	if binding, err = bindings.FindBindingByAuthID(rdnSequence, serviceType.UUID, vars["host"], "x509", store); err != nil {
 		utils.RespondError(w, err)
 		return
 	}

--- a/handlers/certificate_handlers_test.go
+++ b/handlers/certificate_handlers_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gorilla/mux"
 	LOGGER "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/suite"
+	"io/ioutil"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -99,9 +100,9 @@ lBlGGSW4gNfL1IYoakRwJiNiqZ+Gb7+6kHDSVneFeO/qJakXzlByjAA6quPbYzSf
 	qSt2 := stores.QServiceType{Name: "s_auth_cert_incorrect", Hosts: []string{"h1_auth_cert", "h1_auth_cert_revoked"}, AuthTypes: []string{"x509", "oidc"}, AuthMethod: "mock-auth", UUID: "uuid_auth_cert_incorrect", Type: "ams", CreatedOn: "2018-05-05T18:04:05Z"}
 	mockstore.ServiceTypes = append(mockstore.ServiceTypes, qSt, qSt2)
 	// append a binding to be used only in auth via cert tests
-	qB := stores.QBinding{Name: "b_auth_cert", ServiceUUID: "uuid_auth_cert", Host: "h1_auth_cert", DN: "CN=localhost,O=COMODO CA Limited,L=Salford,ST=Greater Manchester,C=GB", OIDCToken: "", UniqueKey: "success", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
-	qB2 := stores.QBinding{Name: "b_auth_cert_incorrect", ServiceUUID: "uuid_auth_cert_incorrect", Host: "h1_auth_cert", DN: "CN=localhost,O=COMODO CA Limited,L=Salford,ST=Greater Manchester,C=GB", OIDCToken: "", UniqueKey: "incorrect-retrieval-field", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
-	qB3 := stores.QBinding{Name: "b_auth_cert_revoked", ServiceUUID: "uuid_auth_cert_incorrect", Host: "h1_auth_cert_revoked", DN: "CN=localhost", OIDCToken: "", UniqueKey: "success", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	qB := stores.QBinding{Name: "b_auth_cert", ServiceUUID: "uuid_auth_cert", Host: "h1_auth_cert", AuthIdentifier: "CN=localhost,O=COMODO CA Limited,L=Salford,ST=Greater Manchester,C=GB", AuthType: "x509", UniqueKey: "success", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	qB2 := stores.QBinding{Name: "b_auth_cert_incorrect", ServiceUUID: "uuid_auth_cert_incorrect", Host: "h1_auth_cert", AuthIdentifier: "CN=localhost,O=COMODO CA Limited,L=Salford,ST=Greater Manchester,C=GB", AuthType: "x509", UniqueKey: "incorrect-retrieval-field", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	qB3 := stores.QBinding{Name: "b_auth_cert_revoked", ServiceUUID: "uuid_auth_cert_incorrect", Host: "h1_auth_cert_revoked", AuthIdentifier: "CN=localhost", AuthType: "x509", UniqueKey: "success", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
 	mockstore.Bindings = append(mockstore.Bindings, qB, qB2, qB3)
 
 	// set up cfg
@@ -809,5 +810,6 @@ func (suite *CertificateHandlerSuite) TestAuthViaCertUnknownDN() {
 }
 
 func TestAuthViaCert(t *testing.T) {
+	LOGGER.SetOutput(ioutil.Discard)
 	suite.Run(t, new(CertificateHandlerSuite))
 }

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -75,7 +75,7 @@ var ApiRoutes = []APIRoute{
 	{"authMethod:Delete", "DELETE", "/service-types/{service-type}/hosts/{host}/authm", handlers.AuthMethodDeleteOne, true},
 	{"authMethod:Delete", "PUT", "/service-types/{service-type}/hosts/{host}/authm", handlers.AuthMethodUpdateOne, true},
 	{"bindings:ListAllByServiceTypeAndHost", "GET", "/service-types/{service-type}/hosts/{host}/bindings", handlers.BindingListAllByServiceTypeAndHost, true},
-	{"bindings:ListOneByDN", "GET", "/service-types/{service-type}/hosts/{host}/bindings/{dn}", handlers.BindingListOneByDN, true},
+	{"bindings:ListOneByDN", "GET", "/service-types/{service-type}/hosts/{host}/bindings/{dn}", handlers.BindingListOneByAuthID, true},
 	{"authMethod:ListAll", "GET", "/authm", handlers.AuthMethodListAll, true},
 	{"bindings:create", "POST", "/bindings", handlers.BindingCreate, true},
 	{"bindings:ListAll", "GET", "/bindings", handlers.BindingListAll, true},

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -27,9 +27,9 @@ func (mock *Mockstore) SetUp() {
 	mock.ServiceTypes = append(mock.ServiceTypes, service1, service2, serviceSame1, serviceSame2)
 
 	// Populate Bindings
-	binding1 := QBinding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "unique_key_1", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
-	binding2 := QBinding{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", DN: "test_dn_2", OIDCToken: "", UniqueKey: "unique_key_2", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
-	binding3 := QBinding{Name: "b3", ServiceUUID: "uuid1", Host: "host2", UUID: "b_uuid3", DN: "test_dn_3", OIDCToken: "", UniqueKey: "unique_key_3", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	binding1 := QBinding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	binding2 := QBinding{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", AuthIdentifier: "test_dn_2", UniqueKey: "unique_key_2", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	binding3 := QBinding{Name: "b3", ServiceUUID: "uuid1", Host: "host2", UUID: "b_uuid3", AuthIdentifier: "test_dn_3", UniqueKey: "unique_key_3", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
 	mock.Bindings = append(mock.Bindings, binding1, binding2, binding3)
 
 	// Populate AuthMethods
@@ -114,12 +114,12 @@ func (mock *Mockstore) QueryApiKeyAuthMethods(serviceUUID string, host string) (
 
 }
 
-func (mock *Mockstore) QueryBindingsByDN(dn string, serviceUUID string, host string) ([]QBinding, error) {
+func (mock *Mockstore) QueryBindingsByAuthID(authID string, serviceUUID string, host string, authType string) ([]QBinding, error) {
 
 	var qBindings []QBinding
 
 	for _, qBinding := range mock.Bindings {
-		if qBinding.DN == dn && qBinding.Host == host && qBinding.ServiceUUID == serviceUUID {
+		if qBinding.AuthIdentifier == authID && qBinding.Host == host && qBinding.ServiceUUID == serviceUUID && qBinding.AuthType == authType {
 			qBindings = append(qBindings, qBinding)
 		}
 	}
@@ -174,9 +174,18 @@ func (mock *Mockstore) InsertServiceType(name string, hosts []string, authTypes 
 	return qService, nil
 }
 
-func (mock *Mockstore) InsertBinding(name string, serviceUUID string, host string, uuid string, dn string, oidcToken string, uniqueKey string) (QBinding, error) {
+func (mock *Mockstore) InsertBinding(name string, serviceUUID string, host string, uuid string, authID string, uniqueKey string, authType string) (QBinding, error) {
 
-	qBinding := QBinding{Name: name, ServiceUUID: serviceUUID, Host: host, DN: dn, UUID: uuid, OIDCToken: oidcToken, UniqueKey: uniqueKey, CreatedOn: utils.ZuluTimeNow()}
+	qBinding := QBinding{
+		Name:           name,
+		ServiceUUID:    serviceUUID,
+		Host:           host,
+		UUID:           uuid,
+		AuthIdentifier: authID,
+		UniqueKey:      uniqueKey,
+		AuthType:       authType,
+		CreatedOn:      utils.ZuluTimeNow(),
+	}
 
 	mock.Bindings = append(mock.Bindings, qBinding)
 

--- a/stores/models.go
+++ b/stores/models.go
@@ -16,15 +16,15 @@ type QServiceType struct {
 }
 
 type QBinding struct {
-	Name        string `json:"name" bson:"name"`
-	ServiceUUID string `json:"service_uuid" bson:"service_uuid"`
-	Host        string `json:"host" bson:"host"`
-	DN          string `json:"dn,omitempty" bson:"dn,omitempty"`
-	UUID        string `json:"uuid" bson:"uuid"`
-	OIDCToken   string `json:"oidc_token,omitempty"`
-	UniqueKey   string `json:"unique_key,omitempty"`
-	CreatedOn   string `json:"created_on,omitempty" bson:"created_on,omitempty"`
-	LastAuth    string `json:"last_auth,omitempty" bson:"last_auth,omitempty"`
+	Name           string `json:"name" bson:"name"`
+	ServiceUUID    string `json:"service_uuid" bson:"service_uuid"`
+	Host           string `json:"host" bson:"host"`
+	AuthIdentifier string `json:"auth_identifier" bson:"auth_identifier"`
+	UUID           string `json:"uuid" bson:"uuid"`
+	AuthType       string `json:"auth_type" bson:"auth_type"`
+	UniqueKey      string `json:"unique_key,omitempty"`
+	CreatedOn      string `json:"created_on,omitempty" bson:"created_on,omitempty"`
+	LastAuth       string `json:"last_auth,omitempty" bson:"last_auth,omitempty"`
 }
 
 type QAuthMethod interface{}

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -124,13 +124,21 @@ func (mongo *MongoStore) InsertAuthMethod(am QAuthMethod) error {
 	return err
 }
 
-func (mongo *MongoStore) QueryBindingsByDN(dn string, serviceUUID string, host string) ([]QBinding, error) {
+func (mongo *MongoStore) QueryBindingsByAuthID(authID string, serviceUUID string, host string, authType string) ([]QBinding, error) {
 
 	var qBindings []QBinding
 	var err error
 
 	c := mongo.Session.DB(mongo.Database).C("bindings")
-	err = c.Find(bson.M{"dn": dn, "service_uuid": serviceUUID, "host": host}).All(&qBindings)
+
+	query := bson.M{
+		"auth_identifier": authID,
+		"service_uuid":    serviceUUID,
+		"host":            host,
+		"auth_type":       authType,
+	}
+
+	err = c.Find(query).All(&qBindings)
 
 	if err != nil {
 		LOGGER.Error("STORE", "\t", err.Error())
@@ -199,12 +207,22 @@ func (mongo *MongoStore) InsertServiceType(name string, hosts []string, authType
 }
 
 //InsertBinding inserts a new binding into the datastore
-func (mongo *MongoStore) InsertBinding(name string, serviceUUID string, host string, uuid string, dn string, oidcToken string, uniqueKey string) (QBinding, error) {
+func (mongo *MongoStore) InsertBinding(name string, serviceUUID string, host string, uuid string, authID string, uniqueKey string, authType string) (QBinding, error) {
 
 	var qBinding QBinding
 	var err error
 
-	qBinding = QBinding{Name: name, ServiceUUID: serviceUUID, Host: host, UUID: uuid, DN: dn, OIDCToken: oidcToken, UniqueKey: uniqueKey, CreatedOn: utils.ZuluTimeNow()}
+	qBinding = QBinding{
+		Name:           name,
+		ServiceUUID:    serviceUUID,
+		Host:           host,
+		UUID:           uuid,
+		AuthIdentifier: authID,
+		UniqueKey:      uniqueKey,
+		AuthType:       authType,
+		CreatedOn:      utils.ZuluTimeNow(),
+	}
+
 	db := mongo.Session.DB(mongo.Database)
 	c := db.C("bindings")
 

--- a/stores/store.go
+++ b/stores/store.go
@@ -7,7 +7,7 @@ type Store interface {
 	QueryServiceTypes(name string) ([]QServiceType, error)
 	QueryServiceTypesByUUID(uuid string) ([]QServiceType, error)
 	QueryApiKeyAuthMethods(serviceUUID string, host string) ([]QApiKeyAuthMethod, error)
-	QueryBindingsByDN(dn string, serviceUUID string, host string) ([]QBinding, error)
+	QueryBindingsByAuthID(authID string, serviceUUID string, host string, authType string) ([]QBinding, error)
 	QueryBindingsByUUID(uuid string) ([]QBinding, error)
 	QueryBindings(serviceUUID string, host string) ([]QBinding, error)
 	InsertServiceType(name string, hosts []string, authTypes []string, authMethod string, uuid string, createdOn string, sType string) (QServiceType, error)
@@ -15,7 +15,7 @@ type Store interface {
 	InsertAuthMethod(am QAuthMethod) error
 	DeleteAuthMethod(am QAuthMethod) error
 	DeleteAuthMethodByServiceUUID(serviceUUID string) error
-	InsertBinding(name string, serviceUUID string, host string, uuid string, dn string, oidcToken string, uniqueKey string) (QBinding, error)
+	InsertBinding(name string, serviceUUID string, host string, uuid string, authID string, uniqueKey string, authType string) (QBinding, error)
 	UpdateBinding(original QBinding, updated QBinding) (QBinding, error)
 	UpdateServiceType(original QServiceType, updated QServiceType) (QServiceType, error)
 	UpdateAuthMethod(original QAuthMethod, updated QAuthMethod) (QAuthMethod, error)

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -39,9 +39,9 @@ func (suite *StoreTestSuite) TestSetUp() {
 	qServices = append(qServices, service1, service2, serviceSame1, serviceSame2)
 
 	// Populate Bindings
-	binding1 := QBinding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "unique_key_1", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
-	binding2 := QBinding{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", DN: "test_dn_2", OIDCToken: "", UniqueKey: "unique_key_2", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
-	binding3 := QBinding{Name: "b3", ServiceUUID: "uuid1", Host: "host2", UUID: "b_uuid3", DN: "test_dn_3", OIDCToken: "", UniqueKey: "unique_key_3", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	binding1 := QBinding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	binding2 := QBinding{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", AuthIdentifier: "test_dn_2", UniqueKey: "unique_key_2", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	binding3 := QBinding{Name: "b3", ServiceUUID: "uuid1", Host: "host2", UUID: "b_uuid3", AuthIdentifier: "test_dn_3", UniqueKey: "unique_key_3", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
 
 	qBindings = append(qBindings, binding1, binding2, binding3)
 
@@ -166,12 +166,12 @@ func (suite *StoreTestSuite) TestQueryBindingsByDN() {
 	suite.SetUpStoreTestSuite()
 
 	// normal case
-	expBinding1 := []QBinding{{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "unique_key_1", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}}
-	qBinding1, err1 := suite.Mockstore.QueryBindingsByDN("test_dn_1", "uuid1", "host1")
+	expBinding1 := []QBinding{{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}}
+	qBinding1, err1 := suite.Mockstore.QueryBindingsByAuthID("test_dn_1", "uuid1", "host1", "x509")
 
 	// not found case
 	var expBinding2 []QBinding
-	qBinding2, err2 := suite.Mockstore.QueryBindingsByDN("wrong_dn", "wrong_uuid", "wrong_host")
+	qBinding2, err2 := suite.Mockstore.QueryBindingsByAuthID("wrong_dn", "wrong_uuid", "wrong_host", "x509")
 
 	// tests the normal case
 	suite.Equal(expBinding1, qBinding1)
@@ -187,7 +187,7 @@ func (suite *StoreTestSuite) TestQueryBindingsByUUID() {
 	suite.SetUpStoreTestSuite()
 
 	// normal case
-	expBinding1 := []QBinding{{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "unique_key_1", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}}
+	expBinding1 := []QBinding{{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}}
 	qBinding1, err1 := suite.Mockstore.QueryBindingsByUUID("b_uuid1")
 
 	// not found case
@@ -209,16 +209,16 @@ func (suite *StoreTestSuite) TestQueryBindings() {
 
 	// normal case - with parameters
 	expBindings1 := []QBinding{
-		{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "unique_key_1", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""},
-		{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", DN: "test_dn_2", OIDCToken: "", UniqueKey: "unique_key_2", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""},
+		{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""},
+		{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", AuthIdentifier: "test_dn_2", UniqueKey: "unique_key_2", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""},
 	}
 	qBindings1, err1 := suite.Mockstore.QueryBindings("uuid1", "host1")
 
 	// normal case - without parameters
 	expBindings2 := []QBinding{
-		{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "unique_key_1", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""},
-		{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", DN: "test_dn_2", OIDCToken: "", UniqueKey: "unique_key_2", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""},
-		{Name: "b3", ServiceUUID: "uuid1", Host: "host2", UUID: "b_uuid3", DN: "test_dn_3", OIDCToken: "", UniqueKey: "unique_key_3", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""},
+		{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""},
+		{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", AuthIdentifier: "test_dn_2", UniqueKey: "unique_key_2", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""},
+		{Name: "b3", ServiceUUID: "uuid1", Host: "host2", UUID: "b_uuid3", AuthIdentifier: "test_dn_3", UniqueKey: "unique_key_3", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""},
 	}
 	qBindings2, err2 := suite.Mockstore.QueryBindings("", "")
 
@@ -276,17 +276,16 @@ func (suite *StoreTestSuite) TestInsertBinding() {
 	suite.SetUpStoreTestSuite()
 
 	var expBinding1 QBinding
-	_, err1 := suite.Mockstore.InsertBinding("bIns", "uuid1", "host1", "b_uuid", "test_dn_ins", "", "unique_key_ins")
+	_, err1 := suite.Mockstore.InsertBinding("bIns", "uuid1", "host1", "b_uuid", "test_dn_ins", "unique_key_ins", "x509")
 	// check if the new binding can be found
-	expBindings, _ := suite.Mockstore.QueryBindingsByDN("test_dn_ins", "uuid1", "host1")
+	expBindings, _ := suite.Mockstore.QueryBindingsByAuthID("test_dn_ins", "uuid1", "host1", "x509")
 	expBinding1 = expBindings[0]
 
 	suite.Equal("bIns", expBinding1.Name)
 	suite.Equal("uuid1", expBinding1.ServiceUUID)
 	suite.Equal("host1", expBinding1.Host)
 	suite.Equal("b_uuid", expBinding1.UUID)
-	suite.Equal("test_dn_ins", expBinding1.DN)
-	suite.Equal("", expBinding1.OIDCToken)
+	suite.Equal("test_dn_ins", expBinding1.AuthIdentifier)
 	suite.Equal("unique_key_ins", expBinding1.UniqueKey)
 	suite.Nil(err1)
 }
@@ -295,12 +294,12 @@ func (suite *StoreTestSuite) TestUpdateBinding() {
 
 	suite.SetUpStoreTestSuite()
 
-	original := QBinding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "unique_key_1", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
-	updated := QBinding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", DN: "test_dn_upd", OIDCToken: "", UniqueKey: "unique_key_upd", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	original := QBinding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	updated := QBinding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_upd", UniqueKey: "unique_key_upd", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
 
 	_, err1 := suite.Mockstore.UpdateBinding(original, updated)
 
-	expBindings, _ := suite.Mockstore.QueryBindingsByDN("test_dn_upd", "uuid1", "host1")
+	expBindings, _ := suite.Mockstore.QueryBindingsByAuthID("test_dn_upd", "uuid1", "host1", "x509")
 	expBinding1 := expBindings[0]
 
 	suite.Equal(expBinding1, updated)
@@ -381,14 +380,14 @@ func (suite *StoreTestSuite) TestDeleteBinding() {
 
 	suite.SetUpStoreTestSuite()
 
-	qBinding := QBinding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", DN: "test_dn_1", OIDCToken: "", UniqueKey: "unique_key_1", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	qBinding := QBinding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
 
 	err1 := suite.Mockstore.DeleteBinding(qBinding)
 
 	// check the slice containing the bindings to see if the qBinding was removed
 	expBindings := []QBinding{
-		{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", DN: "test_dn_2", OIDCToken: "", UniqueKey: "unique_key_2", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""},
-		{Name: "b3", ServiceUUID: "uuid1", Host: "host2", UUID: "b_uuid3", DN: "test_dn_3", OIDCToken: "", UniqueKey: "unique_key_3", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""},
+		{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", AuthIdentifier: "test_dn_2", UniqueKey: "unique_key_2", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""},
+		{Name: "b3", ServiceUUID: "uuid1", Host: "host2", UUID: "b_uuid3", AuthIdentifier: "test_dn_3", UniqueKey: "unique_key_3", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""},
 	}
 	qBindings, _ := suite.Mockstore.QueryBindings("", "")
 


### PR DESCRIPTION
Apply the following changes to the binding structure:
1) Rename the **dn** field to **auth_identifier**
2) Add an extra field, **auth_type** that declares the type of the auth identifier

For example, if we provide a certificate's **dn** to the **auth_identifier field**, we should declare its **auth_type** as **x509**

The permitted **auth_types** a binding can have, are determined by the supported auth types of the service it belongs to(service_uuid)

Also refactor internal methods to use these extra fields, update swagger and mkdocks