### PR TITLE
ARGO-1737 Add support for headers auth method

### DIFF
--- a/authmethods/api_key_auth_test.go
+++ b/authmethods/api_key_auth_test.go
@@ -92,6 +92,6 @@ func (suite *ApiKeyAuthMethodTestSuite) TestUpdate() {
 
 }
 
-func TestApiKeyAuthMethod_Fill(t *testing.T) {
+func TestApiKeyAuthMethodSuite(t *testing.T) {
 	suite.Run(t, new(ApiKeyAuthMethodTestSuite))
 }

--- a/authmethods/authmethods.go
+++ b/authmethods/authmethods.go
@@ -16,6 +16,7 @@ type AuthMethodInit func() AuthMethod
 
 var AuthMethodsTypes = map[string]AuthMethodInit{
 	"api-key": NewApiKeyAuthMethod,
+	"headers": NewHeadersAuthMethod,
 }
 
 // A function type that refers to all the query functions for all the respective tuh method types
@@ -23,6 +24,7 @@ type QueryAuthMethodFinder func(serviceUUID string, host string, store stores.St
 
 var QueryAuthMethodFinders = map[string]QueryAuthMethodFinder{
 	"api-key": ApiKeyAuthFinder,
+	"headers": HeadersAuthFinder,
 }
 
 type AuthMethod interface {

--- a/authmethods/authmethods_test.go
+++ b/authmethods/authmethods_test.go
@@ -135,7 +135,12 @@ func (suite *AuthMethodsTestSuite) TestAuthMethodFIndAll() {
 	amb1 := BasicAuthMethod{ServiceUUID: "uuid1", Host: "host1", Port: 9000, Type: "api-key", UUID: "am_uuid_1", CreatedOn: ""}
 	am1 := &ApiKeyAuthMethod{AccessKey: "access_key"}
 	am1.BasicAuthMethod = amb1
-	expAmList.AuthMethods = append(expAmList.AuthMethods, am1)
+
+	amb2 := BasicAuthMethod{ServiceUUID: "uuid2", Host: "host3", Port: 9000, Type: "headers", UUID: "am_uuid_2", CreatedOn: ""}
+	am2 := &HeadersAuthMethod{Headers: map[string]string{"x-api-key": "key-1", "Accept": "application/json"}}
+	am2.BasicAuthMethod = amb2
+
+	expAmList.AuthMethods = append(expAmList.AuthMethods, am1, am2)
 
 	aMList, err1 := AuthMethodFindAll(mockstore)
 
@@ -162,7 +167,7 @@ func (suite *AuthMethodsTestSuite) TestAuthMethodDelete() {
 
 	err1 := AuthMethodDelete(am1, mockstore)
 
-	suite.Equal(0, len(mockstore.AuthMethods))
+	suite.Equal(1, len(mockstore.AuthMethods))
 
 	suite.Nil(err1)
 }

--- a/authmethods/headers_auth.go
+++ b/authmethods/headers_auth.go
@@ -1,0 +1,208 @@
+package authmethods
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"github.com/ARGOeu/argo-api-authn/bindings"
+	"github.com/ARGOeu/argo-api-authn/config"
+	"github.com/ARGOeu/argo-api-authn/servicetypes"
+	"github.com/ARGOeu/argo-api-authn/stores"
+	"github.com/ARGOeu/argo-api-authn/utils"
+	LOGGER "github.com/sirupsen/logrus"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+)
+
+type HeadersAuthMethod struct {
+	BasicAuthMethod
+	Headers map[string]string `json:"headers" required:"true"`
+}
+
+// TempHeadersAuthMethod  represents the fields that are allowed to be modified
+type TempHeadersAuthMethod struct {
+	TempBasicAuthMethod
+	Headers map[string]string `json:"headers" required:"true"`
+}
+
+func NewHeadersAuthMethod() AuthMethod {
+	return new(HeadersAuthMethod)
+}
+
+func (m *HeadersAuthMethod) Validate(store stores.Store) error {
+
+	var err error
+
+	// check if the embedded struct is valid
+	if err = m.BasicAuthMethod.Validate(store); err != nil {
+		return err
+	}
+
+	// check if all required field have been provided
+	if err = utils.ValidateRequired(*m); err != nil {
+		err := utils.APIErrEmptyRequiredField("auth method", err.Error())
+		return err
+	}
+
+	// check that the headers map is not empty
+	if len(m.Headers) == 0 {
+		err := utils.APIErrEmptyRequiredField("auth method", utils.GenericEmptyRequiredField("headers").Error())
+		return err
+	}
+
+	return err
+}
+
+func (m *HeadersAuthMethod) Update(r io.ReadCloser) (AuthMethod, error) {
+
+	var err error
+	var authMBytes []byte
+	var tempAM TempHeadersAuthMethod
+
+	var updatedAM = NewHeadersAuthMethod()
+
+	// first fill the temp auth method with the already existing data
+	// convert the existing auth method to bytes
+	if authMBytes, err = json.Marshal(*m); err != nil {
+		err := utils.APIGenericInternalError(err.Error())
+		return updatedAM, err
+	}
+
+	// then load the bytes into the temp auth method
+	if err = json.Unmarshal(authMBytes, &tempAM); err != nil {
+		err := utils.APIGenericInternalError(err.Error())
+		return updatedAM, err
+	}
+
+	// check the validity of the JSON and fill the temp auth method object with the updated data
+	if err = json.NewDecoder(r).Decode(&tempAM); err != nil {
+		err := utils.APIErrBadRequest(err.Error())
+		return updatedAM, err
+	}
+
+	// close the reader
+	if err = r.Close(); err != nil {
+		err := utils.APIGenericInternalError(err.Error())
+		return updatedAM, err
+	}
+
+	// fill the updated auth method with the already existing data
+	if err := utils.CopyFields(*m, updatedAM); err != nil {
+		err = utils.APIGenericInternalError(err.Error())
+		return updatedAM, err
+	}
+
+	// transfer the updated temporary data to the updated auth method object
+	// in order to override the outdated fields
+	// convert to bytes
+	if authMBytes, err = json.Marshal(tempAM); err != nil {
+		err := utils.APIGenericInternalError(err.Error())
+		return updatedAM, err
+	}
+
+	// then load the bytes
+	if err = json.Unmarshal(authMBytes, updatedAM); err != nil {
+		err := utils.APIGenericInternalError(err.Error())
+		return updatedAM, err
+	}
+
+	return updatedAM, err
+}
+
+func (m *HeadersAuthMethod) RetrieveAuthResource(binding bindings.Binding, serviceType servicetypes.ServiceType, cfg *config.Config) (map[string]interface{}, error) {
+
+	var externalResp map[string]interface{}
+	var err error
+	var ok bool
+	var resp *http.Response
+	var authResource interface{}
+	var retrievalField string
+	var path string
+
+	if retrievalField, ok = cfg.ServiceTypesRetrievalFields[serviceType.Type]; !ok {
+		err = utils.APIGenericInternalError("Backend error")
+		LOGGER.Errorf("The retrieval field for type: %v was not found in the config retrieval fields: %v", serviceType.Type, cfg.ServiceTypesRetrievalFields)
+		return externalResp, err
+	}
+
+	if path, ok = cfg.ServiceTypesPaths[serviceType.Type]; !ok {
+		err = utils.APIGenericInternalError("Backend error")
+		LOGGER.Errorf("The path for type: %v was not found in the config retrieval fields: %v", serviceType.Type, cfg.ServiceTypesPaths)
+		return externalResp, err
+	}
+
+	// build the path that identifies the resource we are going to request
+	resourcePath := fmt.Sprintf("https://%v:%v%v", m.Host, strconv.Itoa(m.Port), path)
+	resourcePath = strings.Replace(resourcePath, "{{identifier}}", binding.UniqueKey, 1)
+
+	// build the client and execute the request
+	transCfg := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: !cfg.VerifySSL},
+	}
+
+	client := &http.Client{Transport: transCfg, Timeout: time.Duration(30 * time.Second)}
+
+	req, err := http.NewRequest(http.MethodGet, resourcePath, nil)
+	if err != nil {
+		err = utils.APIGenericInternalError(err.Error())
+	}
+
+	// populate the request with the headers
+	for k, v := range m.Headers {
+		req.Header.Add(k, v)
+	}
+
+	resp, err = client.Do(req)
+	if err != nil {
+		err = utils.APIGenericInternalError(err.Error())
+		return externalResp, err
+	}
+
+	// evaluate the response
+	if resp.StatusCode >= 400 {
+		// convert the entire response body into a string and include into a genericAPIError
+		buf := bytes.Buffer{}
+		buf.ReadFrom(resp.Body)
+		err = utils.APIGenericInternalError(buf.String())
+		return externalResp, err
+	}
+
+	// get the response from the service type
+	if err = json.NewDecoder(resp.Body).Decode(&externalResp); err != nil {
+		err = utils.APIGenericInternalError(err.Error())
+		return externalResp, err
+	}
+
+	defer resp.Body.Close()
+
+	// check if the retrieval field that we need is present in the response
+	if authResource, ok = externalResp[retrievalField]; !ok {
+		err = utils.APIGenericInternalError(fmt.Sprintf("The specified retrieval field: `%v` was not found in the response body of the service type", retrievalField))
+		return externalResp, err
+	}
+
+	// if everything went ok, return the appropriate response field
+	return map[string]interface{}{"token": authResource}, err
+
+}
+
+func HeadersAuthFinder(serviceUUID string, host string, store stores.Store) ([]stores.QAuthMethod, error) {
+
+	var err error
+	var qAms []stores.QAuthMethod
+	var qApiAms []stores.QHeadersAuthMethod
+
+	if qApiAms, err = store.QueryHeadersAuthMethods(serviceUUID, host); err != nil {
+		return qAms, err
+	}
+
+	for _, apim := range qApiAms {
+		qAms = append(qAms, &apim)
+	}
+
+	return qAms, err
+}

--- a/authmethods/headers_auth_test.go
+++ b/authmethods/headers_auth_test.go
@@ -1,0 +1,90 @@
+package authmethods
+
+import (
+	"github.com/ARGOeu/argo-api-authn/stores"
+	"github.com/stretchr/testify/suite"
+	"testing"
+)
+
+type HeadersAuthMethodTestSuite struct {
+	suite.Suite
+}
+
+func (suite *HeadersAuthMethodTestSuite) TestNewHeadersAuthMethod() {
+
+	apk1 := NewHeadersAuthMethod()
+
+	suite.Equal(&HeadersAuthMethod{}, apk1)
+}
+
+func (suite *HeadersAuthMethodTestSuite) TestValidate() {
+
+	mockstore := &stores.Mockstore{Server: "localhost", Database: "test_db"}
+	mockstore.SetUp()
+
+	// normal case
+	amb2 := BasicAuthMethod{ServiceUUID: "uuid2", Host: "host3", Port: 9000, Type: "headers", UUID: "am_uuid_2", CreatedOn: ""}
+	ham := HeadersAuthMethod{BasicAuthMethod: amb2, Headers: map[string]string{"x-api-key": "headers=key-1", "Accept": "application/json"}}
+	err1 := ham.Validate(mockstore)
+
+	// empty headers
+	ham2 := HeadersAuthMethod{BasicAuthMethod: amb2}
+	err2 := ham2.Validate(mockstore)
+
+	suite.Nil(err1)
+	suite.Equal("auth method object contains empty fields. empty value for field: headers", err2.Error())
+}
+
+func (suite *HeadersAuthMethodTestSuite) TestHeadersAuthFinder() {
+
+	mockstore := &stores.Mockstore{Server: "localhost", Database: "test_db"}
+	mockstore.SetUp()
+
+	var expectedQams []stores.QAuthMethod
+
+	// normal case
+	amb2 := stores.QBasicAuthMethod{ServiceUUID: "uuid2", Host: "host3", Port: 9000, Type: "headers", UUID: "am_uuid_2", CreatedOn: ""}
+	ham := stores.QHeadersAuthMethod{QBasicAuthMethod: amb2, Headers: map[string]string{"x-api-key": "key-1", "Accept": "application/json"}}
+	expectedQams = append(expectedQams, &ham)
+
+	qAms, err1 := HeadersAuthFinder("uuid2", "host3", mockstore)
+
+	// nothing found
+	qAms2, err2 := HeadersAuthFinder("unknown_uuid", "host", mockstore)
+
+	suite.Equal(expectedQams, qAms)
+	suite.Equal(0, len(qAms2))
+
+	suite.Nil(err1)
+	suite.Nil(err2)
+}
+
+func (suite *HeadersAuthMethodTestSuite) TestUpdate() {
+
+	amb2 := BasicAuthMethod{ServiceUUID: "uuid2", Host: "host4", Port: 9000, Type: "headers", UUID: "am_uuid_2", CreatedOn: ""}
+	ham := HeadersAuthMethod{BasicAuthMethod: amb2, Headers: map[string]string{"x-api-key": "key-2", "Accept": "application/json"}}
+
+	// normal case - update some fields
+	amb2 = BasicAuthMethod{ServiceUUID: "uuid2", Host: "host4", Port: 9000, Type: "headers", UUID: "am_uuid_2", CreatedOn: ""}
+	hamUpd1 := HeadersAuthMethod{BasicAuthMethod: amb2, Headers: map[string]string{"x-api-key": "key-2", "Accept": "application/json"}}
+	r1 := ConvertAuthMethodToReadCloser(&hamUpd1)
+	a1, err1 := hamUpd1.Update(r1)
+
+	// update fields that aren't supposed to be updated
+	apkUpd2 := &HeadersAuthMethod{}
+	baUpd2 := BasicAuthMethod{ServiceUUID: "uuid1", Host: "host1", Port: 9000, Type: "some_api-key", UUID: "some_uuid", CreatedOn: "some_time"}
+	apkUpd2.BasicAuthMethod = baUpd2
+	r2 := ConvertAuthMethodToReadCloser(apkUpd2)
+	a2, err2 := apkUpd2.Update(r2)
+
+	suite.Equal(&ham, a1)
+	suite.NotEqual(ham, a2)
+
+	suite.Nil(err1)
+	suite.Nil(err2)
+
+}
+
+func TestHeadersAuthMethodSuite(t *testing.T) {
+	suite.Run(t, new(HeadersAuthMethodTestSuite))
+}

--- a/bindings/binding_test.go
+++ b/bindings/binding_test.go
@@ -146,7 +146,8 @@ func (suite *BindingTestSuite) TestFindAllBindings() {
 	binding1 := Binding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
 	binding2 := Binding{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", AuthIdentifier: "test_dn_2", UniqueKey: "unique_key_2", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
 	binding3 := Binding{Name: "b3", ServiceUUID: "uuid1", Host: "host2", UUID: "b_uuid3", AuthIdentifier: "test_dn_3", UniqueKey: "unique_key_3", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
-	expectedBL.Bindings = append(expectedBL.Bindings, binding1, binding2, binding3)
+	binding4 := Binding{Name: "b4", ServiceUUID: "uuid2", Host: "host3", UUID: "b_uuid4", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	expectedBL.Bindings = append(expectedBL.Bindings, binding1, binding2, binding3, binding4)
 
 	bl, err := FindAllBindings(mockstore)
 

--- a/config.json
+++ b/config.json
@@ -7,7 +7,7 @@
   "certificate_key":"/path/to/key",
   "service_token": "token",
   "supported_auth_types": ["x509", "oidc"],
-  "supported_auth_methods": ["api-key", "x-api-token"],
+  "supported_auth_methods": ["api-key", "headers"],
   "supported_service_types": ["ams", "web-api", "custom"],
   "verify_ssl": true,
   "trust_unknown_cas": false,

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -51,8 +51,10 @@ paths:
                   type: string
              auth_method:
               type: string
+              enum: [api-key, headers]
              type:
               type: string
+              enum: [ams, web-api]
       tags:
         - Service Types
       responses:
@@ -195,13 +197,17 @@ paths:
                 type: integer
              access_key:
                 type: string
+             headers:
+                type: object
+                additionalProperties:
+                  type: string
       tags:
         - Service Types
       responses:
         201:
           description: Returns the newly created auth method
           schema:
-            $ref: '#/definitions/APIKeyAuthMethod'
+            $ref: '#/definitions/AuthMethod'
         400:
           $ref: "#/responses/400"
         401:
@@ -240,7 +246,7 @@ paths:
         200:
           description: Returns the information of the requested auth method
           schema:
-            $ref: '#/definitions/APIKeyAuthMethod'
+            $ref: '#/definitions/AuthMethod'
         400:
           $ref: "#/responses/400"
         401:
@@ -288,7 +294,7 @@ paths:
         201:
           description: Returns the updated auth method
           schema:
-            $ref: '#/definitions/APIKeyAuthMethod'
+            $ref: '#/definitions/AuthMethod'
         400:
           $ref: "#/responses/400"
         401:
@@ -414,7 +420,7 @@ paths:
         200:
           description: Returns the information of all authentication methods
           schema:
-            $ref: '#/definitions/APIKeyAuthMethods'
+            $ref: '#/definitions/AuthMethods'
         401:
           $ref: "#/responses/401"
         403:
@@ -697,32 +703,39 @@ definitions:
         description: supported authentication types
       auth_method:
         type: string
+        enum: [api-key, headers]
         description: the authentication method that the sercvice supports
       uuid:
         type: string
         description: uuid assosiciatd with the service type
       type:
         type: string
-        description: service type's type, either AMS, web-api or custom
+        description: service type's type, either AMS or web-api
       created_on:
         type: string
+        enum: [ams, web-api]
         description: datetime of creation
 
-  APIKeyAuthMethods:
+  AuthMethods:
     type: object
     properties:
       auth_methods:
         type: array
         items:
-          $ref: '#/definitions/APIKeyAuthMethod'
+          $ref: '#/definitions/AuthMethod'
 
 
-  APIKeyAuthMethod:
+  AuthMethod:
     type: object
     properties:
       access_key:
         type: string
         description: key needed too access the service type
+      headers:
+        type: object
+        description: key-value pairs that represnt the headers that are going to be used if the auth method is of type headers
+        additionalProperties:
+          type: string
       host:
         type: string
         description: host of the service type
@@ -734,13 +747,13 @@ definitions:
         description: port of the service type host
       type:
         type: string
-        description: type of the auth emthod
+        enum: [api-key, headers]
       uuid:
         type: string
         description: auth method's uuid
       created_on:
         type: string
-        description: the type of the auth method
+        description: when the auth method was created
 
 
   TokenResponse:
@@ -756,20 +769,6 @@ definitions:
         type: array
         items:
           $ref: '#/definitions/ServiceType'
-
-  Host:
-    type: object
-    properties:
-      name:
-        type: string
-        description: hostname
-
-  AuthType:
-    type: object
-    properties:
-      name:
-        type: string
-        description: type name
 
   ErrorMsg:
     type: object

--- a/docs/v1/docs/api_authmethods.md
+++ b/docs/v1/docs/api_authmethods.md
@@ -3,16 +3,16 @@
 ## [POST] Manage Auth Methods - Create New Auth Method
 
 This request creates a new auth method for the given service type. The type of the auth method
-as well as some of its predefined fields will be decided by the service-tye's `auth_method` and `type `fields.
+as well as some of its predefined fields will be decided by the service-type's `auth_method` and `type `fields.
 E.g. for a service-type of type `ams` with an auth_method of type `api-key`, it will create an api-key auth method
 with predeclared fields for `path` and `retrieval_field` that are common across all type `ams` service-types.
 Of course you can always override the default's if you like.
 
+## API Key Auth methods
 #### Fields
 
 - path: Combined with the `host` and the `port` is represents the URL where the external resource is located. We use it to map the x509 certificate or any other auth mechanism to the needed token
 - access_key: In the case of an api-key method, the access key specifies te `key` to use in order to access the external resource
-- retrieval_field: The response field from the external service that will contain the attribute we are looking for. e.g. `token`
 
 ### Request
 
@@ -36,6 +36,39 @@ curl -X POST -H "Content-Type: application/json"
             "port": 9000,
         }
 ```
+
+## Headers Auth methods
+#### Fields
+
+- path: Combined with the `host` and the `port` is represents the URL where the external resource is located. We use it to map the x509 certificate or any other auth mechanism to the needed token
+- headers: A collection of `key value pairs` that will be used as request headers when accessing the respective service type
+
+### Request
+
+```
+POST /v1/service-types/{Name}/authm`
+```
+
+
+### Example request
+```
+curl -X POST -H "Content-Type: application/json"
+  "https://{URL}/v1/service-types/{Name}/authm?key={key_in_the_config}"
+```
+
+### Post Body
+
+```
+        {
+            "headers": {
+                "header-1": "value-1",
+                "header-2": "value-2"
+            },
+            "host": "127.0.0.1",
+            "port": 9000
+        }
+```
+
 
 ### Response
 

--- a/handlers/binding_handlers_test.go
+++ b/handlers/binding_handlers_test.go
@@ -438,6 +438,16 @@ func (suite *BindingHandlersSuite) TestBindingListAll() {
    "unique_key": "unique_key_3",
    "auth_type": "x509",
    "created_on": "2018-05-05T15:04:05Z"
+  },
+  {
+   "name": "b4",
+   "service_uuid": "uuid2",
+   "host": "host3",
+   "uuid": "b_uuid4",
+   "auth_identifier": "test_dn_1",
+   "unique_key": "unique_key_1",
+   "auth_type": "x509",
+   "created_on": "2018-05-05T15:04:05Z"
   }
  ]
 }`

--- a/handlers/service_type_handlers_test.go
+++ b/handlers/service_type_handlers_test.go
@@ -543,10 +543,10 @@ func (suite *ServiceTypeHandlersSuite) TestServiceTypeListAll() {
    "auth_types": [
     "x509"
    ],
-   "auth_method": "api-key",
+   "auth_method": "headers",
    "uuid": "uuid2",
    "created_on": "2018-05-05T18:04:05Z",
-   "type": "ams"
+   "type": "web-api"
   },
   {
    "name": "same_name",

--- a/servicetypes/service_type_test.go
+++ b/servicetypes/service_type_test.go
@@ -164,7 +164,7 @@ func (suite *ServiceTestSuite) TestFindAllServiceTypes() {
 	// normal case outcome - all services
 	expQServicesAll := []ServiceType{
 		{Name: "s1", Hosts: []string{"host1", "host2", "host3"}, AuthTypes: []string{"x509", "oidc"}, AuthMethod: "api-key", UUID: "uuid1", CreatedOn: "2018-05-05T18:04:05Z", Type: "ams"},
-		{Name: "s2", Hosts: []string{"host3", "host4"}, AuthTypes: []string{"x509"}, AuthMethod: "api-key", UUID: "uuid2", CreatedOn: "2018-05-05T18:04:05Z", Type: "ams"},
+		{Name: "s2", Hosts: []string{"host3", "host4"}, AuthTypes: []string{"x509"}, AuthMethod: "headers", UUID: "uuid2", CreatedOn: "2018-05-05T18:04:05Z", Type: "web-api"},
 		{Name: "same_name"},
 		{Name: "same_name"},
 	}
@@ -283,8 +283,8 @@ func (suite *ServiceTestSuite) TestDeleteServiceType() {
 	// check if the service type, bindings and auth methods are deleted as well
 	_, errNotFound := FindServiceTypeByUUID("uuid1", mockstore)
 
-	suite.Equal(0, len(mockstore.Bindings))
-	suite.Equal(0, len(mockstore.Bindings))
+	suite.Equal(1, len(mockstore.Bindings))
+	suite.Equal(1, len(mockstore.AuthMethods))
 
 	suite.Equal("Service-type was not found", errNotFound.Error())
 	suite.Nil(err1)

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -21,7 +21,7 @@ func (mock *Mockstore) SetUp() {
 
 	// Populate services
 	service1 := QServiceType{Name: "s1", Hosts: []string{"host1", "host2", "host3"}, AuthTypes: []string{"x509", "oidc"}, AuthMethod: "api-key", UUID: "uuid1", CreatedOn: "2018-05-05T18:04:05Z", Type: "ams"}
-	service2 := QServiceType{Name: "s2", Hosts: []string{"host3", "host4"}, AuthTypes: []string{"x509"}, AuthMethod: "api-key", UUID: "uuid2", CreatedOn: "2018-05-05T18:04:05Z", Type: "ams"}
+	service2 := QServiceType{Name: "s2", Hosts: []string{"host3", "host4"}, AuthTypes: []string{"x509"}, AuthMethod: "headers", UUID: "uuid2", CreatedOn: "2018-05-05T18:04:05Z", Type: "web-api"}
 	serviceSame1 := QServiceType{Name: "same_name"}
 	serviceSame2 := QServiceType{Name: "same_name"}
 	mock.ServiceTypes = append(mock.ServiceTypes, service1, service2, serviceSame1, serviceSame2)
@@ -30,13 +30,19 @@ func (mock *Mockstore) SetUp() {
 	binding1 := QBinding{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
 	binding2 := QBinding{Name: "b2", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid2", AuthIdentifier: "test_dn_2", UniqueKey: "unique_key_2", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
 	binding3 := QBinding{Name: "b3", ServiceUUID: "uuid1", Host: "host2", UUID: "b_uuid3", AuthIdentifier: "test_dn_3", UniqueKey: "unique_key_3", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
-	mock.Bindings = append(mock.Bindings, binding1, binding2, binding3)
+	binding4 := QBinding{Name: "b4", ServiceUUID: "uuid2", Host: "host3", UUID: "b_uuid4", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}
+	mock.Bindings = append(mock.Bindings, binding1, binding2, binding3, binding4)
 
 	// Populate AuthMethods
 	amb1 := QBasicAuthMethod{ServiceUUID: "uuid1", Host: "host1", Port: 9000, Type: "api-key", UUID: "am_uuid_1", CreatedOn: ""}
 	am1 := &QApiKeyAuthMethod{AccessKey: "access_key"}
 	am1.QBasicAuthMethod = amb1
-	mock.AuthMethods = append(mock.AuthMethods, am1)
+
+	amb2 := QBasicAuthMethod{ServiceUUID: "uuid2", Host: "host3", Port: 9000, Type: "headers", UUID: "am_uuid_2", CreatedOn: ""}
+	am2 := &QHeadersAuthMethod{Headers: map[string]string{"x-api-key": "key-1", "Accept": "application/json"}}
+	am2.QBasicAuthMethod = amb2
+
+	mock.AuthMethods = append(mock.AuthMethods, am1, am2)
 }
 
 func (mock *Mockstore) Close() {
@@ -104,6 +110,34 @@ func (mock *Mockstore) QueryApiKeyAuthMethods(serviceUUID string, host string) (
 
 	for _, am := range mock.AuthMethods {
 		if qAuthm, ok = am.(*QApiKeyAuthMethod); ok {
+			if qAuthm.ServiceUUID == serviceUUID && qAuthm.Host == host {
+				qAuthms = append(qAuthms, *qAuthm)
+			}
+		}
+	}
+
+	return qAuthms, err
+
+}
+
+func (mock *Mockstore) QueryHeadersAuthMethods(serviceUUID string, host string) ([]QHeadersAuthMethod, error) {
+
+	var qAuthms []QHeadersAuthMethod
+	var err error
+	var ok bool
+	var qAuthm *QHeadersAuthMethod
+
+	if serviceUUID == "" && host == "" {
+		for _, am := range mock.AuthMethods {
+			if qAuthm, ok = am.(*QHeadersAuthMethod); ok {
+				qAuthms = append(qAuthms, *qAuthm)
+			}
+		}
+		return qAuthms, nil
+	}
+
+	for _, am := range mock.AuthMethods {
+		if qAuthm, ok = am.(*QHeadersAuthMethod); ok {
 			if qAuthm.ServiceUUID == serviceUUID && qAuthm.Host == host {
 				qAuthms = append(qAuthms, *qAuthm)
 			}

--- a/stores/models.go
+++ b/stores/models.go
@@ -43,6 +43,11 @@ type QApiKeyAuthMethod struct {
 	AccessKey        string `json:"access_key" bson:"access_key"`
 }
 
+type QHeadersAuthMethod struct {
+	QBasicAuthMethod `bson:",inline"`
+	Headers          map[string]string `json:"headers" bson:"headers"`
+}
+
 type QAuthMethodFactory struct{}
 
 func (f *QAuthMethodFactory) Create(amType string) (QAuthMethod, error) {
@@ -65,8 +70,13 @@ type QAuthMethodInit func() QAuthMethod
 
 var QAuthMethodsTypes = map[string]QAuthMethodInit{
 	"api-key": NewQApiKeyAuthMethod,
+	"headers": NewQHeadersAuthMethod,
 }
 
 func NewQApiKeyAuthMethod() QAuthMethod {
 	return new(QApiKeyAuthMethod)
+}
+
+func NewQHeadersAuthMethod() QAuthMethod {
+	return new(QHeadersAuthMethod)
 }

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -108,6 +108,30 @@ func (mongo *MongoStore) QueryApiKeyAuthMethods(serviceUUID string, host string)
 	return qAuthms, err
 }
 
+func (mongo *MongoStore) QueryHeadersAuthMethods(serviceUUID string, host string) ([]QHeadersAuthMethod, error) {
+
+	var err error
+	var qAuthms []QHeadersAuthMethod
+
+	var query = bson.M{"service_uuid": serviceUUID, "host": host, "type": "headers"}
+
+	// if there is no serviceUUID and host provided, return all api key auth methods
+	if serviceUUID == "" && host == "" {
+		query = bson.M{"type": "headers"}
+	}
+
+	c := mongo.Session.DB(mongo.Database).C("auth_methods")
+	err = c.Find(query).All(&qAuthms)
+
+	if err != nil {
+		LOGGER.Error("STORE", "\t", err.Error())
+		err = utils.APIErrDatabase(err.Error())
+		return qAuthms, err
+	}
+
+	return qAuthms, err
+}
+
 func (mongo *MongoStore) InsertAuthMethod(am QAuthMethod) error {
 
 	var err error

--- a/stores/store.go
+++ b/stores/store.go
@@ -7,6 +7,7 @@ type Store interface {
 	QueryServiceTypes(name string) ([]QServiceType, error)
 	QueryServiceTypesByUUID(uuid string) ([]QServiceType, error)
 	QueryApiKeyAuthMethods(serviceUUID string, host string) ([]QApiKeyAuthMethod, error)
+	QueryHeadersAuthMethods(serviceUUID string, host string) ([]QHeadersAuthMethod, error)
 	QueryBindingsByAuthID(authID string, serviceUUID string, host string, authType string) ([]QBinding, error)
 	QueryBindingsByUUID(uuid string) ([]QBinding, error)
 	QueryBindings(serviceUUID string, host string) ([]QBinding, error)


### PR DESCRIPTION
Create a new AuthMethod implementation called HeadersAuthMethod that allows the user to declare various headers that will be used as is when authn has to interact with the respective service type. 

Format:
        {
            "headers": {
                "header-1": "value-1",
                "header-2": "value-2"
            },
            "host": "127.0.0.1",
            "port": 9000
        }