### PR TITLE
ARGO-2331 Authn user creation scripts should use project admin tokens

### DIFF
--- a/bin/argo-api-authn-scripts/ams-create-users-cloud-info.py
+++ b/bin/argo-api-authn-scripts/ams-create-users-cloud-info.py
@@ -295,10 +295,8 @@ def create_users(config, verify):
             usr_create = {'projects': [project], 'email': contact_email}
 
             # create the user
-            ams_usr_crt_req = requests.post(
-                "https://" + ams_host + "/v1/users/" + user_binding_name +
-                "?key=" + ams_token,
-                data=json.dumps(usr_create), verify=verify)
+            api_url = 'https://{0}/v1/projects/{1}/members/{2}?key={3}'.format(ams_host, ams_project, user_binding_name, ams_token)
+            ams_usr_crt_req = requests.post(url=api_url, data=json.dumps(usr_create), verify=verify)
             LOGGER.info(ams_usr_crt_req.text)
 
             ams_user_uuid = ""
@@ -320,10 +318,8 @@ def create_users(config, verify):
 
             # If the user already exists, Get user by username
             if ams_usr_crt_req.status_code == 409:
-
-                ams_usr_get_req = requests.get(
-                    "https://" + ams_host + "/v1/users/" +
-                    user_binding_name + "?key=" + ams_token, verify=verify)
+                proj_member_list_url = "https://{0}/v1/projects/{1}/members/{2}?key={3}".format(ams_host, ams_project, user_binding_name, ams_token)
+                ams_usr_get_req = requests.get(url=proj_member_list_url, verify=verify)
 
                 # if the user retrieval was ok
                 if ams_usr_get_req.status_code == 200:

--- a/bin/argo-api-authn-scripts/ams-create-users-gocdb.py
+++ b/bin/argo-api-authn-scripts/ams-create-users-gocdb.py
@@ -282,7 +282,8 @@ def create_users(config, verify):
             usr_create = {'projects': [project], 'email': contact_email}
 
             # create the user
-            ams_usr_crt_req = requests.post("https://"+ams_host+"/v1/users/" + user_binding_name + "?key=" + ams_token, data=json.dumps(usr_create), verify=verify)
+            api_url = 'https://{0}/v1/projects/{1}/members/{2}?key={3}'.format(ams_host, ams_project, user_binding_name, ams_token)
+            ams_usr_crt_req = requests.post(url=api_url, data=json.dumps(usr_create), verify=verify)
             LOGGER.info(ams_usr_crt_req.text)
 
             # if the response doesn't contain the field uuid, it means the user was not created


### PR DESCRIPTION
Update the two user creation scripts to now use the projects: members add API Call, in order to create the respective ams users which require project admin access, instead of the general /v1/users create which required service admin access.