### PR TITLE
ARGO-2493 Binding name should be unique

### DIFF
--- a/handlers/binding_handlers.go
+++ b/handlers/binding_handlers.go
@@ -136,7 +136,7 @@ func BindingListOneByUUID(w http.ResponseWriter, r *http.Request) {
 	// url vars
 	vars := mux.Vars(r)
 
-	if binding, err = bindings.FindBindingByUUID(vars["uuid"], store); err != nil {
+	if binding, err = bindings.FindBindingByUUIDAndName(vars["uuid"], "", store); err != nil {
 		utils.RespondError(w, err)
 		return
 	}
@@ -159,7 +159,7 @@ func BindingUpdate(w http.ResponseWriter, r *http.Request) {
 	// url vars
 	vars := mux.Vars(r)
 
-	if originalBinding, err = bindings.FindBindingByUUID(vars["uuid"], store); err != nil {
+	if originalBinding, err = bindings.FindBindingByUUIDAndName(vars["uuid"], "", store); err != nil {
 		utils.RespondError(w, err)
 		return
 	}
@@ -199,7 +199,7 @@ func BindingDelete(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
 	// check if the binding exists
-	if resourceBinding, err = bindings.FindBindingByUUID(vars["uuid"], store); err != nil {
+	if resourceBinding, err = bindings.FindBindingByUUIDAndName(vars["uuid"], "", store); err != nil {
 		utils.RespondError(w, err)
 		return
 	}

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -161,13 +161,31 @@ func (mock *Mockstore) QueryBindingsByAuthID(authID string, serviceUUID string, 
 	return qBindings, nil
 }
 
-func (mock *Mockstore) QueryBindingsByUUID(uuid string) ([]QBinding, error) {
+func (mock *Mockstore) QueryBindingsByUUIDAndName(uuid, name string) ([]QBinding, error) {
 
 	var qBindings []QBinding
 
-	for _, qBinding := range mock.Bindings {
-		if qBinding.UUID == uuid {
-			qBindings = append(qBindings, qBinding)
+	if uuid != "" && name == "" {
+		for _, qBinding := range mock.Bindings {
+			if qBinding.UUID == uuid {
+				qBindings = append(qBindings, qBinding)
+			}
+		}
+	}
+
+	if uuid == "" && name != "" {
+		for _, qBinding := range mock.Bindings {
+			if qBinding.Name == name {
+				qBindings = append(qBindings, qBinding)
+			}
+		}
+	}
+
+	if uuid != "" && name != "" {
+		for _, qBinding := range mock.Bindings {
+			if qBinding.UUID == uuid && qBinding.Name == name {
+				qBindings = append(qBindings, qBinding)
+			}
 		}
 	}
 

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -173,13 +173,23 @@ func (mongo *MongoStore) QueryBindingsByAuthID(authID string, serviceUUID string
 	return qBindings, err
 }
 
-func (mongo *MongoStore) QueryBindingsByUUID(uuid string) ([]QBinding, error) {
+func (mongo *MongoStore) QueryBindingsByUUIDAndName(uuid, name string) ([]QBinding, error) {
 
 	var qBindings []QBinding
 	var err error
 
+	q := bson.M{}
+
+	if uuid != "" {
+		q["uuid"] = uuid
+	}
+
+	if name != "" {
+		q["name"] = name
+	}
+
 	c := mongo.Session.DB(mongo.Database).C("bindings")
-	err = c.Find(bson.M{"uuid": uuid}).All(&qBindings)
+	err = c.Find(q).All(&qBindings)
 
 	if err != nil {
 		LOGGER.Error("STORE", "\t", err.Error())

--- a/stores/store.go
+++ b/stores/store.go
@@ -9,7 +9,7 @@ type Store interface {
 	QueryApiKeyAuthMethods(serviceUUID string, host string) ([]QApiKeyAuthMethod, error)
 	QueryHeadersAuthMethods(serviceUUID string, host string) ([]QHeadersAuthMethod, error)
 	QueryBindingsByAuthID(authID string, serviceUUID string, host string, authType string) ([]QBinding, error)
-	QueryBindingsByUUID(uuid string) ([]QBinding, error)
+	QueryBindingsByUUIDAndName(uuid, name string) ([]QBinding, error)
 	QueryBindings(serviceUUID string, host string) ([]QBinding, error)
 	InsertServiceType(name string, hosts []string, authTypes []string, authMethod string, uuid string, createdOn string, sType string) (QServiceType, error)
 	DeleteServiceTypeByUUID(uuid string) error

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -216,15 +216,18 @@ func (suite *StoreTestSuite) TestQueryBindingsByUUID() {
 
 	// normal case
 	expBinding1 := []QBinding{{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}}
-	qBinding1, err1 := suite.Mockstore.QueryBindingsByUUID("b_uuid1")
+	qBinding1, err1 := suite.Mockstore.QueryBindingsByUUIDAndName("b_uuid1", "")
+	qBinding1_name, err1_name := suite.Mockstore.QueryBindingsByUUIDAndName("", "b1")
 
 	// not found case
 	var expBinding2 []QBinding
-	qBinding2, err2 := suite.Mockstore.QueryBindingsByUUID("wrong_uuid")
+	qBinding2, err2 := suite.Mockstore.QueryBindingsByUUIDAndName("wrong_uuid", "")
 
 	// tests the normal case
+	suite.Equal(expBinding1, qBinding1_name)
 	suite.Equal(expBinding1, qBinding1)
 	suite.Nil(err1)
+	suite.Nil(err1_name)
 
 	//tests the not found case
 	suite.Equal(expBinding2, qBinding2)


### PR DESCRIPTION
Update the internal functions of the service to be able to handle binding name uniqueness. This functionality is needed in order to be able to target bindings with other info(name) rather than uuid.

The two affected API calls are BindingsCreate and BindingsUpdate.