### PR TITLE
ARGO-2494 Modify the BindingCreate API route to include name in the path

### DIFF
--- a/handlers/binding_handlers.go
+++ b/handlers/binding_handlers.go
@@ -20,12 +20,16 @@ func BindingCreate(w http.ResponseWriter, r *http.Request) {
 
 	var binding bindings.Binding
 
+	vars := mux.Vars(r)
+
 	// check the validity of the JSON
 	if err = json.NewDecoder(r.Body).Decode(&binding); err != nil {
 		err := utils.APIErrBadRequest(err.Error())
 		utils.RespondError(w, err)
 		return
 	}
+
+	binding.Name = vars["name"]
 
 	if binding, err = bindings.CreateBinding(binding, store); err != nil {
 		utils.RespondError(w, err)

--- a/handlers/binding_handlers.go
+++ b/handlers/binding_handlers.go
@@ -136,7 +136,7 @@ func BindingListOneByUUID(w http.ResponseWriter, r *http.Request) {
 	// url vars
 	vars := mux.Vars(r)
 
-	if binding, err = bindings.FindBindingByUUID(vars["uuid"], store); err != nil {
+	if binding, err = bindings.FindBindingByUUIDAndName(vars["uuid"], "", store); err != nil {
 		utils.RespondError(w, err)
 		return
 	}
@@ -159,7 +159,7 @@ func BindingUpdate(w http.ResponseWriter, r *http.Request) {
 	// url vars
 	vars := mux.Vars(r)
 
-	if originalBinding, err = bindings.FindBindingByUUID(vars["uuid"], store); err != nil {
+	if originalBinding, err = bindings.FindBindingByUUIDAndName(vars["uuid"], "", store); err != nil {
 		utils.RespondError(w, err)
 		return
 	}
@@ -199,7 +199,7 @@ func BindingDelete(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
 	// check if the binding exists
-	if resourceBinding, err = bindings.FindBindingByUUID(vars["uuid"], store); err != nil {
+	if resourceBinding, err = bindings.FindBindingByUUIDAndName(vars["uuid"], "", store); err != nil {
 		utils.RespondError(w, err)
 		return
 	}

--- a/handlers/binding_handlers_test.go
+++ b/handlers/binding_handlers_test.go
@@ -24,7 +24,6 @@ type BindingHandlersSuite struct {
 func (suite *BindingHandlersSuite) TestBindingCreate() {
 
 	postJSON := `{
-	"name": "new_binding",
 	"service_uuid": "uuid1",
     "host": "host1",
     "auth_identifier": "test_dn",
@@ -32,7 +31,7 @@ func (suite *BindingHandlersSuite) TestBindingCreate() {
     "auth_type": "x509"
 }`
 
-	req, err := http.NewRequest("POST", "http://localhost:8080/bindings", bytes.NewBuffer([]byte(postJSON)))
+	req, err := http.NewRequest("POST", "http://localhost:8080/bindings/new_binding", bytes.NewBuffer([]byte(postJSON)))
 	if err != nil {
 		LOGGER.Error(err.Error())
 	}
@@ -45,7 +44,7 @@ func (suite *BindingHandlersSuite) TestBindingCreate() {
 
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
-	router.HandleFunc("/bindings", WrapConfig(BindingCreate, mockstore, cfg))
+	router.HandleFunc("/bindings/{name}", WrapConfig(BindingCreate, mockstore, cfg))
 	router.ServeHTTP(w, req)
 	suite.Equal(201, w.Code)
 	createdBind := bindings.Binding{}
@@ -57,44 +56,6 @@ func (suite *BindingHandlersSuite) TestBindingCreate() {
 	suite.Equal("test_dn", createdBind.AuthIdentifier)
 	suite.Equal("uni_key", createdBind.UniqueKey)
 	suite.Equal("x509", createdBind.AuthType)
-}
-
-// TestBindingCreateMissingFieldName tests the case where the binding doesn't contain the  name field
-func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldName() {
-
-	postJSON := `{
-	"service_uuid": "uuid1",
-    "host": "host1",
-    "auth_identifier": "test_dn",
-    "unique_key": "uni_key"
-}`
-
-	expRespJSON := `{
- "error": {
-  "message": "binding object contains empty fields. empty value for field: name",
-  "code": 422,
-  "status": "UNPROCESSABLE ENTITY"
- }
-}`
-
-	req, err := http.NewRequest("POST", "http://localhost:8080/bindings", bytes.NewBuffer([]byte(postJSON)))
-	if err != nil {
-		LOGGER.Error(err.Error())
-	}
-
-	mockstore := &stores.Mockstore{Server: "localhost", Database: "test_db"}
-	mockstore.SetUp()
-
-	cfg := &config.Config{}
-	_ = cfg.ConfigSetUp("../config/configuration-test-files/test-conf.json")
-
-	router := mux.NewRouter().StrictSlash(true)
-	w := httptest.NewRecorder()
-	router.HandleFunc("/bindings", WrapConfig(BindingCreate, mockstore, cfg))
-	router.ServeHTTP(w, req)
-	suite.Equal(422, w.Code)
-	suite.Equal(expRespJSON, w.Body.String())
-
 }
 
 // TestBindingCreateInvalidJSON tests the case where the request body is not a vlaid json
@@ -115,7 +76,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateInvalidJSON() {
  }
 }`
 
-	req, err := http.NewRequest("POST", "http://localhost:8080/bindings", bytes.NewBuffer([]byte(postJSON)))
+	req, err := http.NewRequest("POST", "http://localhost:8080/bindings/b1", bytes.NewBuffer([]byte(postJSON)))
 	if err != nil {
 		LOGGER.Error(err.Error())
 	}
@@ -128,7 +89,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateInvalidJSON() {
 
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
-	router.HandleFunc("/bindings", WrapConfig(BindingCreate, mockstore, cfg))
+	router.HandleFunc("/bindings/{name}", WrapConfig(BindingCreate, mockstore, cfg))
 	router.ServeHTTP(w, req)
 	suite.Equal(400, w.Code)
 	suite.Equal(expRespJSON, w.Body.String())
@@ -139,7 +100,6 @@ func (suite *BindingHandlersSuite) TestBindingCreateInvalidJSON() {
 func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldServiceUUID() {
 
 	postJSON := `{
-    "name": "b1",
     "host": "host1",
     "auth_identifier": "test_dn",
     "unique_key": "uni_key"
@@ -153,7 +113,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldServiceUUID() {
  }
 }`
 
-	req, err := http.NewRequest("POST", "http://localhost:8080/bindings", bytes.NewBuffer([]byte(postJSON)))
+	req, err := http.NewRequest("POST", "http://localhost:8080/bindings/b1", bytes.NewBuffer([]byte(postJSON)))
 	if err != nil {
 		LOGGER.Error(err.Error())
 	}
@@ -166,7 +126,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldServiceUUID() {
 
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
-	router.HandleFunc("/bindings", WrapConfig(BindingCreate, mockstore, cfg))
+	router.HandleFunc("/bindings/{name}", WrapConfig(BindingCreate, mockstore, cfg))
 	router.ServeHTTP(w, req)
 	suite.Equal(422, w.Code)
 	suite.Equal(expRespJSON, w.Body.String())
@@ -177,7 +137,6 @@ func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldServiceUUID() {
 func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldHost() {
 
 	postJSON := `{
-    "name": "b1",
 	"service_uuid": "uuid1",
     "auth_identifier": "test_dn",
     "unique_key": "uni_key"
@@ -191,7 +150,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldHost() {
  }
 }`
 
-	req, err := http.NewRequest("POST", "http://localhost:8080/bindings", bytes.NewBuffer([]byte(postJSON)))
+	req, err := http.NewRequest("POST", "http://localhost:8080/bindings/b1", bytes.NewBuffer([]byte(postJSON)))
 	if err != nil {
 		LOGGER.Error(err.Error())
 	}
@@ -204,7 +163,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldHost() {
 
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
-	router.HandleFunc("/bindings", WrapConfig(BindingCreate, mockstore, cfg))
+	router.HandleFunc("/bindings/{name}", WrapConfig(BindingCreate, mockstore, cfg))
 	router.ServeHTTP(w, req)
 	suite.Equal(422, w.Code)
 	suite.Equal(expRespJSON, w.Body.String())
@@ -215,7 +174,6 @@ func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldHost() {
 func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldAuthID() {
 
 	postJSON := `{
-    "name": "b1",
 	"service_uuid": "uuid1",
     "host": "host1",
     "unique_key": "uni_key"
@@ -229,7 +187,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldAuthID() {
  }
 }`
 
-	req, err := http.NewRequest("POST", "http://localhost:8080/bindings", bytes.NewBuffer([]byte(postJSON)))
+	req, err := http.NewRequest("POST", "http://localhost:8080/bindings/b1", bytes.NewBuffer([]byte(postJSON)))
 	if err != nil {
 		LOGGER.Error(err.Error())
 	}
@@ -242,7 +200,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldAuthID() {
 
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
-	router.HandleFunc("/bindings", WrapConfig(BindingCreate, mockstore, cfg))
+	router.HandleFunc("/bindings/{name}", WrapConfig(BindingCreate, mockstore, cfg))
 	router.ServeHTTP(w, req)
 	suite.Equal(422, w.Code)
 	suite.Equal(expRespJSON, w.Body.String())
@@ -253,7 +211,6 @@ func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldAuthID() {
 func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldUniqueKey() {
 
 	postJSON := `{
-    "name": "b1",
     "service_uuid": "uuid1",
     "host": "host1",
     "auth_identifier": "test_dn",
@@ -268,7 +225,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldUniqueKey() {
  }
 }`
 
-	req, err := http.NewRequest("POST", "http://localhost:8080/bindings", bytes.NewBuffer([]byte(postJSON)))
+	req, err := http.NewRequest("POST", "http://localhost:8080/bindings/b1", bytes.NewBuffer([]byte(postJSON)))
 	if err != nil {
 		LOGGER.Error(err.Error())
 	}
@@ -281,7 +238,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldUniqueKey() {
 
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
-	router.HandleFunc("/bindings", WrapConfig(BindingCreate, mockstore, cfg))
+	router.HandleFunc("/bindings/{name}", WrapConfig(BindingCreate, mockstore, cfg))
 	router.ServeHTTP(w, req)
 	suite.Equal(422, w.Code)
 	suite.Equal(expRespJSON, w.Body.String())
@@ -291,7 +248,6 @@ func (suite *BindingHandlersSuite) TestBindingCreateMissingFieldUniqueKey() {
 func (suite *BindingHandlersSuite) TestBindingCreateUnknownService() {
 
 	postJSON := `{
-    "name": "b1",
     "service_uuid": "unknown",
     "host": "host1",
     "auth_identifier": "test_dn",
@@ -307,7 +263,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateUnknownService() {
  }
 }`
 
-	req, err := http.NewRequest("POST", "http://localhost:8080/bindings", bytes.NewBuffer([]byte(postJSON)))
+	req, err := http.NewRequest("POST", "http://localhost:8080/bindings/b1", bytes.NewBuffer([]byte(postJSON)))
 	if err != nil {
 		LOGGER.Error(err.Error())
 	}
@@ -320,7 +276,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateUnknownService() {
 
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
-	router.HandleFunc("/bindings", WrapConfig(BindingCreate, mockstore, cfg))
+	router.HandleFunc("/bindings/{name}", WrapConfig(BindingCreate, mockstore, cfg))
 	router.ServeHTTP(w, req)
 	suite.Equal(404, w.Code)
 	suite.Equal(expRespJSON, w.Body.String())
@@ -330,7 +286,6 @@ func (suite *BindingHandlersSuite) TestBindingCreateUnknownService() {
 func (suite *BindingHandlersSuite) TestBindingCreateUnknownHost() {
 
 	postJSON := `{
-    "name": "b1",
     "service_uuid": "uuid1",
     "host": "unknown",
     "auth_identifier": "test_dn",
@@ -346,7 +301,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateUnknownHost() {
  }
 }`
 
-	req, err := http.NewRequest("POST", "http://localhost:8080/bindings", bytes.NewBuffer([]byte(postJSON)))
+	req, err := http.NewRequest("POST", "http://localhost:8080/bindings/b1", bytes.NewBuffer([]byte(postJSON)))
 	if err != nil {
 		LOGGER.Error(err.Error())
 	}
@@ -359,7 +314,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateUnknownHost() {
 
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
-	router.HandleFunc("/bindings", WrapConfig(BindingCreate, mockstore, cfg))
+	router.HandleFunc("/bindings/{name}", WrapConfig(BindingCreate, mockstore, cfg))
 	router.ServeHTTP(w, req)
 	suite.Equal(404, w.Code)
 	suite.Equal(expRespJSON, w.Body.String())
@@ -369,7 +324,6 @@ func (suite *BindingHandlersSuite) TestBindingCreateUnknownHost() {
 func (suite *BindingHandlersSuite) TestBindingCreateDNAlreadyExists() {
 
 	postJSON := `{
-    "name": "b1",
     "service_uuid": "uuid1",
     "host": "host1",
     "auth_identifier": "test_dn_1",
@@ -385,7 +339,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateDNAlreadyExists() {
  }
 }`
 
-	req, err := http.NewRequest("POST", "http://localhost:8080/bindings", bytes.NewBuffer([]byte(postJSON)))
+	req, err := http.NewRequest("POST", "http://localhost:8080/bindings/b1", bytes.NewBuffer([]byte(postJSON)))
 	if err != nil {
 		LOGGER.Error(err.Error())
 	}
@@ -398,7 +352,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateDNAlreadyExists() {
 
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
-	router.HandleFunc("/bindings", WrapConfig(BindingCreate, mockstore, cfg))
+	router.HandleFunc("/bindings/{name}", WrapConfig(BindingCreate, mockstore, cfg))
 	router.ServeHTTP(w, req)
 	suite.Equal(409, w.Code)
 	suite.Equal(expRespJSON, w.Body.String())
@@ -408,7 +362,6 @@ func (suite *BindingHandlersSuite) TestBindingCreateDNAlreadyExists() {
 func (suite *BindingHandlersSuite) TestBindingCreateNameAlreadyExists() {
 
 	postJSON := `{
-    "name": "b1",
     "service_uuid": "uuid1",
     "host": "host1",
     "auth_identifier": "test_dn_4",
@@ -424,7 +377,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateNameAlreadyExists() {
  }
 }`
 
-	req, err := http.NewRequest("POST", "http://localhost:8080/bindings", bytes.NewBuffer([]byte(postJSON)))
+	req, err := http.NewRequest("POST", "http://localhost:8080/bindings/b1", bytes.NewBuffer([]byte(postJSON)))
 	if err != nil {
 		LOGGER.Error(err.Error())
 	}
@@ -437,7 +390,7 @@ func (suite *BindingHandlersSuite) TestBindingCreateNameAlreadyExists() {
 
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
-	router.HandleFunc("/bindings", WrapConfig(BindingCreate, mockstore, cfg))
+	router.HandleFunc("/bindings/{name}", WrapConfig(BindingCreate, mockstore, cfg))
 	router.ServeHTTP(w, req)
 	suite.Equal(409, w.Code)
 	suite.Equal(expRespJSON, w.Body.String())

--- a/postman/authn_ci-cd_tests.postman_collection.json
+++ b/postman/authn_ci-cd_tests.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
 		"_postman_id": "9486152a-2158-4b9f-8888-6e4c0619568a",
-		"name": "AuthN CI/CD tests",
+		"name": "authn_ci-cd_tests",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
 	"item": [
@@ -187,17 +187,18 @@
 				],
 				"body": {
 					"mode": "raw",
-					"raw": "{\n\t\"name\": \"authn-cicd\",\n\t\"service_uuid\": \"{{st-uuid}}\",\n\t\"host\": \"{{ams-host}}\",\n\t\"auth_identifier\": \"CN=jenkins.einfra.grnet.gr,OU=E-Infrastructures Department,O=National Infrastructures for Research and Technology (GRNET),L=Athens,C=GR\",\n\t\"unique_key\": \"3530bde2-a8bc-417b-9f8e-c36dedeedafb\",\n\t\"auth_type\": \"x509\"\n}\n"
+					"raw": "{\n\t\"service_uuid\": \"{{st-uuid}}\",\n\t\"host\": \"{{ams-host}}\",\n\t\"auth_identifier\": \"CN=jenkins.einfra.grnet.gr,OU=E-Infrastructures Department,O=National Infrastructures for Research and Technology (GRNET),L=Athens,C=GR\",\n\t\"unique_key\": \"3530bde2-a8bc-417b-9f8e-c36dedeedafb\",\n\t\"auth_type\": \"x509\"\n}\n"
 				},
 				"url": {
-					"raw": "https://{{authn-host}}/v1/bindings?key={{authn-token}}",
+					"raw": "https://{{authn-host}}/v1/bindings/authn-cicd?key={{authn-token}}",
 					"protocol": "https",
 					"host": [
 						"{{authn-host}}"
 					],
 					"path": [
 						"v1",
-						"bindings"
+						"bindings",
+						"authn-cicd"
 					],
 					"query": [
 						{

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -77,7 +77,7 @@ var ApiRoutes = []APIRoute{
 	{"bindings:ListAllByServiceTypeAndHost", "GET", "/service-types/{service-type}/hosts/{host}/bindings", handlers.BindingListAllByServiceTypeAndHost, true},
 	{"bindings:ListOneByDN", "GET", "/service-types/{service-type}/hosts/{host}/bindings/{dn}", handlers.BindingListOneByAuthID, true},
 	{"authMethod:ListAll", "GET", "/authm", handlers.AuthMethodListAll, true},
-	{"bindings:create", "POST", "/bindings", handlers.BindingCreate, true},
+	{"bindings:create", "POST", "/bindings/{name}", handlers.BindingCreate, true},
 	{"bindings:ListAll", "GET", "/bindings", handlers.BindingListAll, true},
 	{"bindings:update", "PUT", "/bindings/{uuid}", handlers.BindingUpdate, true},
 	{"bindings:ListOneByUUID", "GET", "/bindings/{uuid}", handlers.BindingListOneByUUID, true},

--- a/stores/mock.go
+++ b/stores/mock.go
@@ -161,13 +161,31 @@ func (mock *Mockstore) QueryBindingsByAuthID(authID string, serviceUUID string, 
 	return qBindings, nil
 }
 
-func (mock *Mockstore) QueryBindingsByUUID(uuid string) ([]QBinding, error) {
+func (mock *Mockstore) QueryBindingsByUUIDAndName(uuid, name string) ([]QBinding, error) {
 
 	var qBindings []QBinding
 
-	for _, qBinding := range mock.Bindings {
-		if qBinding.UUID == uuid {
-			qBindings = append(qBindings, qBinding)
+	if uuid != "" && name == "" {
+		for _, qBinding := range mock.Bindings {
+			if qBinding.UUID == uuid {
+				qBindings = append(qBindings, qBinding)
+			}
+		}
+	}
+
+	if uuid == "" && name != "" {
+		for _, qBinding := range mock.Bindings {
+			if qBinding.Name == name {
+				qBindings = append(qBindings, qBinding)
+			}
+		}
+	}
+
+	if uuid != "" && name != "" {
+		for _, qBinding := range mock.Bindings {
+			if qBinding.UUID == uuid && qBinding.Name == name {
+				qBindings = append(qBindings, qBinding)
+			}
 		}
 	}
 

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -173,13 +173,23 @@ func (mongo *MongoStore) QueryBindingsByAuthID(authID string, serviceUUID string
 	return qBindings, err
 }
 
-func (mongo *MongoStore) QueryBindingsByUUID(uuid string) ([]QBinding, error) {
+func (mongo *MongoStore) QueryBindingsByUUIDAndName(uuid, name string) ([]QBinding, error) {
 
 	var qBindings []QBinding
 	var err error
 
+	q := bson.M{}
+
+	if uuid != "" {
+		q["uuid"] = uuid
+	}
+
+	if name != "" {
+		q["name"] = name
+	}
+
 	c := mongo.Session.DB(mongo.Database).C("bindings")
-	err = c.Find(bson.M{"uuid": uuid}).All(&qBindings)
+	err = c.Find(q).All(&qBindings)
 
 	if err != nil {
 		LOGGER.Error("STORE", "\t", err.Error())

--- a/stores/store.go
+++ b/stores/store.go
@@ -9,7 +9,7 @@ type Store interface {
 	QueryApiKeyAuthMethods(serviceUUID string, host string) ([]QApiKeyAuthMethod, error)
 	QueryHeadersAuthMethods(serviceUUID string, host string) ([]QHeadersAuthMethod, error)
 	QueryBindingsByAuthID(authID string, serviceUUID string, host string, authType string) ([]QBinding, error)
-	QueryBindingsByUUID(uuid string) ([]QBinding, error)
+	QueryBindingsByUUIDAndName(uuid, name string) ([]QBinding, error)
 	QueryBindings(serviceUUID string, host string) ([]QBinding, error)
 	InsertServiceType(name string, hosts []string, authTypes []string, authMethod string, uuid string, createdOn string, sType string) (QServiceType, error)
 	DeleteServiceTypeByUUID(uuid string) error

--- a/stores/store_test.go
+++ b/stores/store_test.go
@@ -216,15 +216,18 @@ func (suite *StoreTestSuite) TestQueryBindingsByUUID() {
 
 	// normal case
 	expBinding1 := []QBinding{{Name: "b1", ServiceUUID: "uuid1", Host: "host1", UUID: "b_uuid1", AuthIdentifier: "test_dn_1", UniqueKey: "unique_key_1", AuthType: "x509", CreatedOn: "2018-05-05T15:04:05Z", LastAuth: ""}}
-	qBinding1, err1 := suite.Mockstore.QueryBindingsByUUID("b_uuid1")
+	qBinding1, err1 := suite.Mockstore.QueryBindingsByUUIDAndName("b_uuid1", "")
+	qBinding1_name, err1_name := suite.Mockstore.QueryBindingsByUUIDAndName("", "b1")
 
 	// not found case
 	var expBinding2 []QBinding
-	qBinding2, err2 := suite.Mockstore.QueryBindingsByUUID("wrong_uuid")
+	qBinding2, err2 := suite.Mockstore.QueryBindingsByUUIDAndName("wrong_uuid", "")
 
 	// tests the normal case
+	suite.Equal(expBinding1, qBinding1_name)
 	suite.Equal(expBinding1, qBinding1)
 	suite.Nil(err1)
+	suite.Nil(err1_name)
 
 	//tests the not found case
 	suite.Equal(expBinding2, qBinding2)


### PR DESCRIPTION
Update the BindingCreate api route to include the binding's name in the URL instead of the request body.

New API route would be - /v1/bindings/{binding-name}