### PR TITLE
ARGO-2502 argo-api-authn: Modify the BindingDelete API route to include name in the path

### DIFF
--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -429,11 +429,40 @@ paths:
           $ref: "#/responses/500"
 
   /bindings:
+    get:
+      summary: Retrieves all the bindings
+      description: |
+        Retrieves all the bindings
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+      tags:
+        - Bindings
+      responses:
+        200:
+          description: Returns a list containing all the bindings
+          schema:
+            $ref: '#/definitions/Bindings'
+        400:
+          $ref: "#/responses/400"
+        401:
+          $ref: "#/responses/401"
+        403:
+          $ref: "#/responses/403"
+        500:
+          $ref: "#/responses/500"
+
+  /bindings/{NAME}:
+
     post:
       summary: Create a new binding
       description: |
         Create a new binding
       parameters:
+        - name: NAME
+          in: path
+          description: NAME of the binding
+          required: true
+          type: string
         - $ref: '#/parameters/ApiKey'
         - name: binding information
           in: body
@@ -442,8 +471,6 @@ paths:
           schema:
             type: object
             properties:
-              name:
-                type: string
               service_uuid:
                 type: string
               host:
@@ -477,36 +504,13 @@ paths:
           $ref: "#/responses/500"
 
     get:
-      summary: Retrieves all the bindings
-      description: |
-        Retrieves all the bindings
-      parameters:
-        - $ref: '#/parameters/ApiKey'
-      tags:
-        - Bindings
-      responses:
-        200:
-          description: Returns a list containing all the bindings
-          schema:
-            $ref: '#/definitions/Bindings'
-        400:
-          $ref: "#/responses/400"
-        401:
-          $ref: "#/responses/401"
-        403:
-          $ref: "#/responses/403"
-        500:
-          $ref: "#/responses/500"
-
-  /bindings/{UUID}:
-    get:
       summary: Retrieve information for a specific binding
       description: |
          Retrieve information for a specific binding
       parameters:
-        - name: UUID
+        - name: NAME
           in: path
-          description: UUID of the binding
+          description: NAME of the binding
           required: true
           type: string
         - $ref: '#/parameters/ApiKey'
@@ -532,9 +536,9 @@ paths:
       description: |
          Updates a binding
       parameters:
-        - name: UUID
+        - name: NAME
           in: path
-          description: UUID of the binding
+          description: NAME of the binding
           required: true
           type: string
         - $ref: '#/parameters/ApiKey'
@@ -583,9 +587,9 @@ paths:
       description: |
          Deletes a binding
       parameters:
-        - name: UUID
+        - name: NAME
           in: path
-          description: UUID of the binding
+          description: NAME of the binding
           required: true
           type: string
         - $ref: '#/parameters/ApiKey'

--- a/docs/v1/docs/api_bindings.md
+++ b/docs/v1/docs/api_bindings.md
@@ -20,14 +20,14 @@ This request creates a new binding.
 #### Request
 
 ```
-POST /v1/bindings`
+POST /v1/bindings/{name}`
 ```
 
 ### Example request
 
 ```
 curl -X POST -H "Content-Type: application/json"
-  "https://{URL}/v1/bindings?key={key_in_the_config}"
+  "https://{URL}/v1/bindings/b1?key={key_in_the_config}"
 ```
 
 ##### Post Body
@@ -178,7 +178,7 @@ This request retrieves the information of a binding associated with the provided
 ### Request
     
 ```
-GET /v1/bindings/{uuid}
+GET /v1/bindings/{name}
 ```    
 
 ### Response     
@@ -213,12 +213,12 @@ Please refer to section [Errors](api_errors.md) to see all possible Errors
 This request updates binding. You can specify one or more fields to update.
 The allowed to be updated fields are:
 
-`name, service_uuid, host, dn, oidc_token, unique_key`.
+`name, service_uuid, host, auth_identifier, auth_type, unique_key`.
 
 #### Request
 
 ```
-PUT /v1/bindings/{uuid}
+PUT /v1/bindings/{name}
 ```
 
 ##### Request Body
@@ -261,7 +261,7 @@ This request deletes a binding.
 #### Request
 
 ```
-DELETE /v1/bindings/{uuid}`
+DELETE /v1/bindings/{name}`
 ```
 
 ### Response

--- a/handlers/binding_handlers.go
+++ b/handlers/binding_handlers.go
@@ -203,7 +203,7 @@ func BindingDelete(w http.ResponseWriter, r *http.Request) {
 	vars := mux.Vars(r)
 
 	// check if the binding exists
-	if resourceBinding, err = bindings.FindBindingByUUIDAndName(vars["uuid"], "", store); err != nil {
+	if resourceBinding, err = bindings.FindBindingByUUIDAndName("", vars["name"], store); err != nil {
 		utils.RespondError(w, err)
 		return
 	}

--- a/handlers/binding_handlers_test.go
+++ b/handlers/binding_handlers_test.go
@@ -1209,7 +1209,7 @@ func (suite *BindingHandlersSuite) TestBindingUpdateUnknownUUID() {
 // TestBindingDelete tests the normal case
 func (suite *BindingHandlersSuite) TestBindingDelete() {
 
-	req, err := http.NewRequest("DELETE", "http://localhost:8080/bindings/b_uuid1", nil)
+	req, err := http.NewRequest("DELETE", "http://localhost:8080/bindings/b1", nil)
 	if err != nil {
 		LOGGER.Error(err.Error())
 	}
@@ -1222,7 +1222,7 @@ func (suite *BindingHandlersSuite) TestBindingDelete() {
 
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
-	router.HandleFunc("/bindings/{uuid}", WrapConfig(BindingDelete, mockstore, cfg))
+	router.HandleFunc("/bindings/{name}", WrapConfig(BindingDelete, mockstore, cfg))
 	router.ServeHTTP(w, req)
 	suite.Equal(204, w.Code)
 }

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -81,6 +81,6 @@ var ApiRoutes = []APIRoute{
 	{"bindings:ListAll", "GET", "/bindings", handlers.BindingListAll, true},
 	{"bindings:update", "PUT", "/bindings/{name}", handlers.BindingUpdate, true},
 	{"bindings:ListOneByName", "GET", "/bindings/{name}", handlers.BindingListOneByName, true},
-	{"bindings:delete", "DELETE", "/bindings/{uuid}", handlers.BindingDelete, true},
+	{"bindings:delete", "DELETE", "/bindings/{name}", handlers.BindingDelete, true},
 	{"auth:dn", "GET", "/service-types/{service-type}/hosts/{host}:authx509", handlers.AuthViaCert, false},
 }


### PR DESCRIPTION
Update the DeleteBinding API Route to now be able to target bindings for deletion through their name instead of their UUID.

new API route: DELETE /v1/bindings/{name} instead of /v1/bindings/{uuid}

Also, update swagger docs and mkdocs with all the needed changes.