### PR TITLE
ARGO-2557 Make syslog logging configurable for AuthN

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,10 +32,8 @@ Before you start, you need to issue a valid certificate.
 
 4. Get dependencies(If you plan on contributing to the project else skip this step):
 
-   Argo-api-authN uses the dep tool for dependency handling.
+   Argo-api-authN uses the go modules tool for dependency handling.
     
-    - Install the dep tool. You can find instructions depending on your platform at [Dep](https://github.com/golang/dep).
-
 5. To build the service use the following command:
 
       `go build`
@@ -83,7 +81,8 @@ Before you start, you need to issue a valid certificate.
    "service_types_retrieval_fields": {
    "ams": "token",
    "web-api": "api_key"
-   }
+   },
+   "syslog_enabled": true
  }
  ```
  

--- a/conf/argo-api-authn-config.template
+++ b/conf/argo-api-authn-config.template
@@ -13,5 +13,6 @@
   "trust_unknown_cas": true,
   "verify_certificate": false,
   "service_types_paths": {"ams": "/v1/users:byUUID/{{identifier}}?key={{access_key}}"},
-  "service_types_retrieval_fields": {"ams": "token"}
+  "service_types_retrieval_fields": {"ams": "token"},
+  "syslog_enabled": false
 }

--- a/config.json
+++ b/config.json
@@ -19,5 +19,6 @@
   "service_types_retrieval_fields": {
     "ams": "token",
     "web-api": "api_key"
-  }
+  },
+  "syslog_enabled" : false
 }

--- a/config/config.go
+++ b/config/config.go
@@ -6,7 +6,9 @@ import (
 	"errors"
 	"github.com/ARGOeu/argo-api-authn/utils"
 	LOGGER "github.com/sirupsen/logrus"
+	lSyslog "github.com/sirupsen/logrus/hooks/syslog"
 	"io/ioutil"
+	"log/syslog"
 	"reflect"
 )
 
@@ -26,6 +28,7 @@ type Config struct {
 	VerifyCertificate           bool              `json:"verify_certificate"`
 	ServiceTypesPaths           map[string]string `json:"service_types_paths" required:"true"`
 	ServiceTypesRetrievalFields map[string]string `json:"service_types_retrieval_fields" required:"true"`
+	SyslogEnabled               bool              `json:"syslog_enabled"`
 }
 
 // ConfigSetUp unmarshals a json file specified by the input parameter into the config object
@@ -40,6 +43,13 @@ func (cfg *Config) ConfigSetUp(path string) error {
 
 	if err = json.Unmarshal(data, &cfg); err != nil {
 		return errors.New("Something went wrong while marshaling the json data. Error: " + err.Error())
+	}
+
+	if cfg.SyslogEnabled {
+		hook, err := lSyslog.NewSyslogHook("", "", syslog.LOG_INFO, "")
+		if err == nil {
+			LOGGER.AddHook(hook)
+		}
 	}
 
 	if err = utils.ValidateRequired(*cfg); err != nil {

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -42,6 +42,7 @@ func (suite *ConfigTestSuite) TestConfigSetUp() {
 			"ams":     "token",
 			"web-api": "api_key",
 		},
+		SyslogEnabled: true,
 	}
 
 	//tests the case of a malformed json

--- a/config/configuration-test-files/test-conf.json
+++ b/config/configuration-test-files/test-conf.json
@@ -19,5 +19,6 @@
   "service_types_retrieval_fields": {
     "ams": "token",
     "web-api": "api_key"
-  }
+  },
+  "syslog_enabled": true
 }

--- a/main.go
+++ b/main.go
@@ -16,16 +16,10 @@ import (
 	"github.com/ARGOeu/argo-api-authn/routing"
 	"github.com/ARGOeu/argo-api-authn/stores"
 	LOGGER "github.com/sirupsen/logrus"
-	lSyslog "github.com/sirupsen/logrus/hooks/syslog"
-	"log/syslog"
 )
 
 func init() {
 	LOGGER.SetFormatter(&LOGGER.TextFormatter{FullTimestamp: true, DisableColors: true})
-	hook, err := lSyslog.NewSyslogHook("", "", syslog.LOG_INFO, "")
-	if err == nil {
-		LOGGER.AddHook(hook)
-	}
 }
 
 func main() {


### PR DESCRIPTION
Provide a new configuration parameter **syslog_enabled**(true|false) to control the activation of direct syslog logging.
Making it a boolean will benefit us immediately when the new binary is deployed without having to add an extra configuration field to the authn installations.