### PR TITLE
ARGO-2730 Production release for authn 0.1.5

### DIFF
--- a/argo-api-authn.spec
+++ b/argo-api-authn.spec
@@ -3,7 +3,7 @@
 
 Name: argo-api-authn
 Summary: ARGO Authentication API. Map X509, OICD to token.
-Version: 0.1.4
+Version: 0.1.5
 Release: 1%{?dist}
 License: ASL 2.0
 Buildroot: %{_tmppath}/%{name}-buildroot
@@ -57,6 +57,8 @@ go clean
 %attr(0644,root,root) /usr/lib/systemd/system/argo-api-authn.service
 
 %changelog
+* Wed Nov 18 2020 Agelos Tsalapatis  <agelos.tsal@gmail    .com> - 0.1.5-1%{?dist}
+- Release of argo-api-authn version 0.1.5
 * Thu Jun 13 2019 Agelos Tsalapatis  <agelos.tsal@gmail.com> - 0.1.4-1%{?dist}
 - Release of argo-api-authn version 0.1.4
 * Thu Jun 13 2019 Agelos Tsalapatis  <agelos.tsal@gmail.com> - 0.1.3-1%{?dist}


### PR DESCRIPTION
Release containing 1 feature and 1 bug fix.
- Make syslog configurable
- Fix a nil pointer bug while fetching cert's CRL