### PR TITLE
Remove swagger downstream job trigger

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,6 @@ pipeline {
         success {
             script{
                 if ( env.BRANCH_NAME == 'devel' ) {
-                    build job: '/ARGO-utils/argo-swagger-docs', propagate: false
                     build job: '/ARGO/argodoc/devel', propagate: false
                 } else if ( env.BRANCH_NAME == 'master' ) {
                     build job: '/ARGO/argodoc/master', propagate: false


### PR DESCRIPTION
Due to a change in the Jenkinsfiles orientation this directive is not any more useful.