### PR TITLE
ARGO-3102 authn: Update scripts to handle same DN under multiple endpoints

### DIFF
--- a/bin/argo-api-authn-scripts/ams-create-users-cloud-info.py
+++ b/bin/argo-api-authn-scripts/ams-create-users-cloud-info.py
@@ -11,6 +11,7 @@ import logging.handlers
 import argparse
 import ldap
 import re
+import urllib.parse
 
 # set up logging
 LOGGER = logging.getLogger("AMS User create script per site")
@@ -467,93 +468,134 @@ def create_users(config, verify):
                     format(service_dn.text, ve))
                 continue
 
-            project = {'project': ams_project, 'roles': [users_role]}
-            usr_create = {'projects': [project], 'email': contact_email}
+            # check if the given DN already corresponds to a binding
+            # if the DN is already in use, skip the creation process and only perform the steps where the user
+            # is being assigned to the topic's and sub's acl and the respective topic and subscription are being created.
 
-            # create the user
-            api_url = 'https://{0}/v1/projects/{1}/members/{2}?key={3}'.format(ams_host, ams_project, user_binding_name, ams_token)
-            ams_usr_crt_req = requests.post(url=api_url, data=json.dumps(usr_create), verify=verify)
-            LOGGER.info(ams_usr_crt_req.text)
+            # TODO replace ams(service type name) with config value
+            binding_exists_url = "https://{0}/v1/service-types/ams/hosts/{1}/bindings?key={2}&authID={3}".format(
+                authn_host, authn_service_host, authn_token, urllib.parse.quote_plus(service_dn))
 
-            ams_user_uuid = ""
+            LOGGER.info("Checking if DN {0} is already in use . . . ".format(service_dn))
 
-            # if the response is neither a 200(OK) nor a 409(already exists)
-            # then move on to the next user
-            if ams_usr_crt_req.status_code != 200 and ams_usr_crt_req.status_code != 409:
-                LOGGER.critical("\nUser: " + user_binding_name)
-                LOGGER.critical(
-                    "\nSomething went wrong while creating ams user." +
-                    "\nBody data: " + str(usr_create) + "\nResponse Body: " +
-                    ams_usr_crt_req.text)
-                continue
+            binding_exists_req = requests.get(url=binding_exists_url, verify=verify)
 
-            if ams_usr_crt_req.status_code == 200:
-                ams_user_uuid = ams_usr_crt_req.json()["uuid"]
-                # count how many users have been created
-                user_count += 1
+            # if the binding exists, retrieve it, and use its name for any further process
+            if binding_exists_req.status_code == 200:
+                user_binding_name = binding_exists_req.json()["bindings"][0]["name"]
+                LOGGER.info("DN {0} is in use by the binding with name {1}".format(service_dn, user_binding_name))
 
-            # If the user already exists, Get user by username
-            if ams_usr_crt_req.status_code == 409:
-                proj_member_list_url = "https://{0}/v1/projects/{1}/members/{2}?key={3}".format(ams_host, ams_project, user_binding_name, ams_token)
-                ams_usr_get_req = requests.get(url=proj_member_list_url, verify=verify)
+            # else if the Dn isn't in use, go through the full process of creating or updating an existing binding
+            elif binding_exists_req.status_code == 404:
 
-                # if the user retrieval was ok
-                if ams_usr_get_req.status_code == 200:
-                    LOGGER.info("\nSuccessfully retrieved user {} from ams".format(user_binding_name))
-                    ams_user_uuid = ams_usr_get_req.json()["uuid"]
-                else:
+                usr_create = {'email': contact_email}
+
+                # create the user
+                api_url = 'https://{0}/v1/projects/{1}/members/{2}?key={3}'.format(ams_host, ams_project, user_binding_name, ams_token)
+                ams_usr_crt_req = requests.post(url=api_url, data=json.dumps(usr_create), verify=verify)
+                LOGGER.info(ams_usr_crt_req.text)
+
+                ams_user_uuid = ""
+
+                # if the response is neither a 200(OK) nor a 409(already exists)
+                # then move on to the next user
+                if ams_usr_crt_req.status_code != 200 and ams_usr_crt_req.status_code != 409:
+                    LOGGER.critical("\nUser: " + user_binding_name)
                     LOGGER.critical(
-                        "\nCould not retrieve user {} from ams."
-                        "\n Response {}".format(user_binding_name, ams_usr_get_req.text))
+                        "\nSomething went wrong while creating ams user." +
+                        "\nBody data: " + str(usr_create) + "\nResponse Body: " +
+                        ams_usr_crt_req.text)
                     continue
 
-            # Create the respective AUTH binding
-            bd_data = {
-                'service_uuid': authn_service_uuid,
-                'host': authn_service_host,
-                'auth_identifier': service_dn,
-                'unique_key': ams_user_uuid,
-                "auth_type": "x509"
+                if ams_usr_crt_req.status_code == 200:
+                    ams_user_uuid = ams_usr_crt_req.json()["uuid"]
+                    # count how many users have been created
+                    user_count += 1
+
+                # If the user already exists, Get user by username
+                if ams_usr_crt_req.status_code == 409:
+                    proj_member_list_url = "https://{0}/v1/projects/{1}/members/{2}?key={3}".format(ams_host, ams_project, user_binding_name, ams_token)
+                    ams_usr_get_req = requests.get(url=proj_member_list_url, verify=verify)
+
+                    # if the user retrieval was ok
+                    if ams_usr_get_req.status_code == 200:
+                        LOGGER.info("\nSuccessfully retrieved user {} from ams".format(user_binding_name))
+                        ams_user_uuid = ams_usr_get_req.json()["uuid"]
+                    else:
+                        LOGGER.critical(
+                            "\nCould not retrieve user {} from ams."
+                            "\n Response {}".format(user_binding_name, ams_usr_get_req.text))
+                        continue
+
+                # Create the respective AUTH binding
+                bd_data = {
+                    'service_uuid': authn_service_uuid,
+                    'host': authn_service_host,
+                    'auth_identifier': service_dn,
+                    'unique_key': ams_user_uuid,
+                    "auth_type": "x509"
+                }
+
+                create_binding_url = "https://{0}/v1/bindings/{1}?key={2}".format(authn_host, user_binding_name, authn_token)
+
+                authn_binding_crt_req = requests.post(url=create_binding_url, data=json.dumps(bd_data), verify=verify)
+                LOGGER.info(authn_binding_crt_req.text)
+
+                # if the response is neither a 201(Created) nor a 409(already exists)
+                if authn_binding_crt_req.status_code != 201 and authn_binding_crt_req.status_code != 409:
+                    LOGGER.critical(
+                        "Something went wrong while creating a binding." +
+                        "\nBody data: " + str(bd_data) + "\nResponse: " +
+                        authn_binding_crt_req.text)
+                    continue
+
+                # if the binding already exists, check for an updated DN from gocdb
+                if authn_binding_crt_req.status_code == 409:
+                    retrieve_binding_url = "https://{0}/v1/bindings/{1}?key={2}".format(authn_host, user_binding_name, authn_token)
+                    authn_ret_bind_req = requests.get(url=retrieve_binding_url, verify=verify)
+                    # if the binding retrieval was ok
+                    if authn_ret_bind_req.status_code == 200:
+                        LOGGER.info("\nSuccessfully retrieved binding {} from authn. Checking for DN update.".format(user_binding_name))
+                        binding = authn_ret_bind_req.json()
+                        # check if the dn has changed
+                        if binding["auth_identifier"] != service_dn:
+                            # update the respective binding with the new dn
+                            bind_upd_req_url = "https://{0}/v1/bindings/{1}?key={2}".format(authn_host, user_binding_name, authn_token)
+                            upd_bd_data = {
+                                "auth_identifier": service_dn
+                            }
+                            authn_bind_upd_req = requests.put(url=bind_upd_req_url, data=json.dumps(upd_bd_data), verify=verify)
+                            LOGGER.info(authn_bind_upd_req.text)
+                            if authn_bind_upd_req.status_code == 200:
+                                update_binding_count += 1
+                                update_bindings_names.append(user_binding_name)
+                    else:
+                        LOGGER.critical(
+                            "\nCould not retrieve binding {} from authn."
+                            "\n Response {}".format(user_binding_name, authn_ret_bind_req.text))
+                        continue
+
+            # add the user to the AMS project with corresponding role
+            add_user_project_url = "https://{0}/v1/projects/{1}/members/{2}:add?key={3}".format(ams_host,
+                                                                                                ams_project,
+                                                                                                user_binding_name,
+                                                                                                ams_token)
+
+            add_user_project_req_body = {
+                "project": ams_project,
+                "roles": [users_role]
             }
-            
-            create_binding_url = "https://{0}/v1/bindings/{1}?key={2}".format(authn_host, user_binding_name, authn_token)
-            
-            authn_binding_crt_req = requests.post(url=create_binding_url, data=json.dumps(bd_data), verify=verify)
-            LOGGER.info(authn_binding_crt_req.text)
 
-            # if the response is neither a 201(Created) nor a 409(already exists)
-            if authn_binding_crt_req.status_code != 201 and authn_binding_crt_req.status_code != 409:
-                LOGGER.critical(
-                    "Something went wrong while creating a binding." +
-                    "\nBody data: " + str(bd_data) + "\nResponse: " +
-                    authn_binding_crt_req.text)
+            LOGGER.info("Adding user {0} to project {1} . . .".format(user_binding_name, ams_project))
+
+            add_user_project_req = requests.post(url=add_user_project_url,
+                                                 data=json.dumps(add_user_project_req_body), verify=verify)
+
+            if add_user_project_req.status_code != 200 and add_user_project_req.status_code != 409:
+                LOGGER.info("Could not add user {0} to project {1}.\nResponse {2}".format(user_binding_name,
+                                                                                          ams_project,
+                                                                                          add_user_project_req.text))
                 continue
-
-            # if the binding already exists, check for an updated DN from gocdb
-            if authn_binding_crt_req.status_code == 409:
-                retrieve_binding_url = "https://{0}/v1/bindings/{1}?key={2}".format(authn_host, user_binding_name, authn_token)
-                authn_ret_bind_req = requests.get(url=retrieve_binding_url, verify=verify)
-                # if the binding retrieval was ok
-                if authn_ret_bind_req.status_code == 200:
-                    LOGGER.info("\nSuccessfully retrieved binding {} from authn. Checking for DN update.".format(user_binding_name))
-                    binding = authn_ret_bind_req.json()
-                    # check if the dn has changed
-                    if binding["auth_identifier"] != service_dn:
-                        # update the respective binding with the new dn
-                        bind_upd_req_url = "https://{0}/v1/bindings/{1}?key={2}".format(authn_host, user_binding_name, authn_token)
-                        upd_bd_data = {
-                            "auth_identifier": service_dn
-                        }
-                        authn_bind_upd_req = requests.put(url=bind_upd_req_url, data=json.dumps(upd_bd_data), verify=verify)
-                        LOGGER.info(authn_bind_upd_req.text)
-                        if authn_bind_upd_req.status_code == 200:
-                            update_binding_count += 1
-                            update_bindings_names.append(user_binding_name)
-                else:
-                    LOGGER.critical(
-                        "\nCould not retrieve binding {} from authn."
-                        "\n Response {}".format(user_binding_name, authn_ret_bind_req.text))
-                    continue
 
             # since both the ams user was created or already existed AND the authn binding was created or already existed
             # move to topic and subscription creation

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -37,24 +37,24 @@ paths:
           description: Required service type information
           required: true
           schema:
-           type: object
-           properties:
-             name:
-               type: string
-             hosts:
+            type: object
+            properties:
+              name:
+                type: string
+              hosts:
                 type: array
                 items:
                   type: string
-             auth_types:
+              auth_types:
                 type: array
                 items:
                   type: string
-             auth_method:
-              type: string
-              enum: [api-key, headers]
-             type:
-              type: string
-              enum: [ams, web-api]
+              auth_method:
+                type: string
+                enum: [api-key, headers]
+              type:
+                type: string
+                enum: [ams, web-api]
       tags:
         - Service Types
       responses:
@@ -79,7 +79,7 @@ paths:
       summary: Lists all service types
       description: Lists all service types
       parameters:
-          - $ref: '#/parameters/ApiKey'
+        - $ref: '#/parameters/ApiKey'
       tags:
         - Service Types
       responses:
@@ -135,20 +135,20 @@ paths:
           description:  Required service type information. When updating, you need to provide information ONLY for the fields(s) you are updating .You can updated one or more fields at a time.
           required: true
           schema:
-           type: object
-           properties:
-             name:
-               type: string
-             hosts:
+            type: object
+            properties:
+              name:
+                type: string
+              hosts:
                 type: array
                 items:
                   type: string
-             auth_types:
+              auth_types:
                 type: array
                 items:
                   type: string
-             auth_method:
-              type: string
+              auth_method:
+                type: string
 
       tags:
         - Service Types
@@ -189,15 +189,15 @@ paths:
           description: The auth method will also automatically contain additional information based on the service-type that is associated with. The auth method will be created based on the service-type's auth_method and type fields. E.g. create an api-key auth method for an ams type of service.
           required: true
           schema:
-           type: object
-           properties:
-             host:
-               type: string
-             port:
-                type: integer
-             access_key:
+            type: object
+            properties:
+              host:
                 type: string
-             headers:
+              port:
+                type: integer
+              access_key:
+                type: string
+              headers:
                 type: object
                 additionalProperties:
                   type: string
@@ -278,15 +278,15 @@ paths:
           description: You can update one or more fields in one request.
           required: true
           schema:
-           type: object
-           properties:
-             service_uuid:
-               type: string
-             port:
-               type: integer
-             host:
-               type: string
-             access_key:
+            type: object
+            properties:
+              service_uuid:
+                type: string
+              port:
+                type: integer
+              host:
+                type: string
+              access_key:
                 type: string
       tags:
         - Service Types
@@ -388,6 +388,11 @@ paths:
           description: Name of the host
           required: true
           type: string
+        - name: authID
+          in: query
+          description: authID of a specific binding
+          type: string
+          required: false
         - $ref: '#/parameters/ApiKey'
       tags:
         - Service Types
@@ -506,7 +511,7 @@ paths:
     get:
       summary: Retrieve information for a specific binding
       description: |
-         Retrieve information for a specific binding
+        Retrieve information for a specific binding
       parameters:
         - name: NAME
           in: path
@@ -534,7 +539,7 @@ paths:
     put:
       summary: Updates a binding
       description: |
-         Updates a binding
+        Updates a binding
       parameters:
         - name: NAME
           in: path
@@ -585,7 +590,7 @@ paths:
     delete:
       summary: Deletes a binding
       description: |
-         Deletes a binding
+        Deletes a binding
       parameters:
         - name: NAME
           in: path

--- a/docs/v1/docs/api_bindings.md
+++ b/docs/v1/docs/api_bindings.md
@@ -171,9 +171,50 @@ If the request is successful, the response contains all the bindings under the g
 
 Please refer to section [Errors](api_errors.md) to see all possible Errors
 
-## [GET] Manage Bindings - List One Binding By UUID
+## [GET] Manage Bindings - List One Binding by Auth identifier
 
-This request retrieves the information of a binding associated with the provided uuid.
+This request returns the binding under the provider service type and host matching
+the auth identifier
+    
+### Request
+
+```
+GET /v1/service-types/{service-type}/hosts/{host}/bindings?authID=test_dn
+```
+    
+### Response
+     
+If the request is successful, the response contains all the bindings under the given host and service.
+   
+#### Success Response
+     
+`200 OK`
+     
+```
+  {
+      "bindings": [
+              {
+                  "name": "testb",
+                  "service_uuid": "uuid1",
+                  "host": "host1",
+                  "auth_identifier": "testdn",
+                  "uuid": "p61020d9-bef3-4768-9a03-331ff36e8af4cc",
+                  "unique_key": "key",
+                  "auth_type": "x509",                
+                  "created_on": "2018-05-23T09:25:25Z",
+                  "last_auth": "2018-05-23T09:25:25Z"
+              }
+      ]
+  }
+```
+  
+### Errors
+
+Please refer to section [Errors](api_errors.md) to see all possible Errors
+
+## [GET] Manage Bindings - List One Binding By NAME
+
+This request retrieves the information of a binding associated with the provided name.
     
 ### Request
     

--- a/handlers/binding_handlers_test.go
+++ b/handlers/binding_handlers_test.go
@@ -628,17 +628,22 @@ func (suite *BindingHandlersSuite) TestBindingListAllByServiceTypeAndHostUnknown
 func (suite *BindingHandlersSuite) TestBindingListOneByAuthID() {
 
 	expRespJSON := `{
- "name": "b1",
- "service_uuid": "uuid1",
- "host": "host1",
- "uuid": "b_uuid1",
- "auth_identifier": "test_dn_1",
- "unique_key": "unique_key_1",
- "auth_type": "x509",
- "created_on": "2018-05-05T15:04:05Z"
+ "bindings": [
+  {
+   "name": "b1",
+   "service_uuid": "uuid1",
+   "host": "host1",
+   "uuid": "b_uuid1",
+   "auth_identifier": "test_dn_1",
+   "unique_key": "unique_key_1",
+   "auth_type": "x509",
+   "created_on": "2018-05-05T15:04:05Z"
+  }
+ ]
 }`
 
-	req, err := http.NewRequest("GET", "http://localhost:8080/service-types/s1/hosts/host1/bindings/test_dn_1", nil)
+	req, err := http.NewRequest("GET",
+		"http://localhost:8080/service-types/s1/hosts/host1/bindings?authID=test_dn_1", nil)
 	if err != nil {
 		LOGGER.Error(err.Error())
 	}
@@ -651,7 +656,7 @@ func (suite *BindingHandlersSuite) TestBindingListOneByAuthID() {
 
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
-	router.HandleFunc("/service-types/{service-type}/hosts/{host}/bindings/{dn}", WrapConfig(BindingListOneByAuthID, mockstore, cfg))
+	router.HandleFunc("/service-types/{service-type}/hosts/{host}/bindings", WrapConfig(BindingListAllByServiceTypeAndHost, mockstore, cfg))
 	router.ServeHTTP(w, req)
 	suite.Equal(200, w.Code)
 	suite.Equal(expRespJSON, w.Body.String())
@@ -668,7 +673,8 @@ func (suite *BindingHandlersSuite) TestBindingListOneByDNMultipleEntries() {
  }
 }`
 
-	req, err := http.NewRequest("GET", "http://localhost:8080/service-types/s1/hosts/host1/bindings/test_dn_1", nil)
+	req, err := http.NewRequest("GET",
+		"http://localhost:8080/service-types/s1/hosts/host1/bindings?authID=test_dn_1", nil)
 	if err != nil {
 		LOGGER.Error(err.Error())
 	}
@@ -685,7 +691,7 @@ func (suite *BindingHandlersSuite) TestBindingListOneByDNMultipleEntries() {
 
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
-	router.HandleFunc("/service-types/{service-type}/hosts/{host}/bindings/{dn}", WrapConfig(BindingListOneByAuthID, mockstore, cfg))
+	router.HandleFunc("/service-types/{service-type}/hosts/{host}/bindings", WrapConfig(BindingListAllByServiceTypeAndHost, mockstore, cfg))
 	router.ServeHTTP(w, req)
 	suite.Equal(500, w.Code)
 	suite.Equal(expRespJSON, w.Body.String())
@@ -762,7 +768,8 @@ func (suite *BindingHandlersSuite) TestBindingListOneByDnUnknownDN() {
  }
 }`
 
-	req, err := http.NewRequest("GET", "http://localhost:8080/service-types/s1/hosts/host1/bindings/unknown_dn", nil)
+	req, err := http.NewRequest("GET",
+		"http://localhost:8080/service-types/s1/hosts/host1/bindings?authID=unknown_dn", nil)
 	if err != nil {
 		LOGGER.Error(err.Error())
 	}
@@ -775,7 +782,7 @@ func (suite *BindingHandlersSuite) TestBindingListOneByDnUnknownDN() {
 
 	router := mux.NewRouter().StrictSlash(true)
 	w := httptest.NewRecorder()
-	router.HandleFunc("/service-types/{service-type}/hosts/{host}/bindings/{dn}", WrapConfig(BindingListOneByAuthID, mockstore, cfg))
+	router.HandleFunc("/service-types/{service-type}/hosts/{host}/bindings", WrapConfig(BindingListAllByServiceTypeAndHost, mockstore, cfg))
 	router.ServeHTTP(w, req)
 	suite.Equal(404, w.Code)
 	suite.Equal(expRespJSON, w.Body.String())

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -75,7 +75,6 @@ var ApiRoutes = []APIRoute{
 	{"authMethod:Delete", "DELETE", "/service-types/{service-type}/hosts/{host}/authm", handlers.AuthMethodDeleteOne, true},
 	{"authMethod:Delete", "PUT", "/service-types/{service-type}/hosts/{host}/authm", handlers.AuthMethodUpdateOne, true},
 	{"bindings:ListAllByServiceTypeAndHost", "GET", "/service-types/{service-type}/hosts/{host}/bindings", handlers.BindingListAllByServiceTypeAndHost, true},
-	{"bindings:ListOneByDN", "GET", "/service-types/{service-type}/hosts/{host}/bindings/{dn}", handlers.BindingListOneByAuthID, true},
 	{"authMethod:ListAll", "GET", "/authm", handlers.AuthMethodListAll, true},
 	{"bindings:create", "POST", "/bindings/{name}", handlers.BindingCreate, true},
 	{"bindings:ListAll", "GET", "/bindings", handlers.BindingListAll, true},


### PR DESCRIPTION
Reorganizing the process of user and binding creation by always checking if the given DN already corresponds to an existing binding.

if that's the case, we retrieve the binding that uses the DN and treat it as the binding/user for this specific iteration.That means that instead of creating a new user, we use the already existing binding's name(which maps to a user in ams aswell) and we perform all AMS actions(add to project, add to topic acl etc) with the existing binding's name.

Example:

service1-host-1 and service2-host-1 use the same DN(test-dn).

service1-host-1 with test-dn will be normally created with the corresponding binding and ams user(service-1-host-1-username) and it is assigned to topic service-1-topic.

When the time comes for service2-host-1 to get registered and be assigned to service-2-topic, we see that the dn(test-dn) is already in use, so we retrieve the binding that it belongs to(service-1-host-1-username) and we assign it to service-2-topic.

This way, the client will always retrieve using the DN(test-dn) a user that has access to both service-1-topic and service-2-topic at all times.