### PR TITLE
AM-39 Authn Improvements

### DIFF
--- a/argo-api-authn.spec
+++ b/argo-api-authn.spec
@@ -47,7 +47,11 @@ install --mode 644 src/github.com/ARGOeu/argo-api-authn/argo-api-authn.service %
 %{__rm} -rf %{buildroot}
 export GOPATH=$PWD
 cd src/github.com/ARGOeu/argo-api-authn/
-go clean
+
+export GIT_COMMIT=$(git rev-list -1 HEAD)
+export BUILD_TIME=$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+export CGO_CFLAGS"=-O2 -fstack-protector --param=ssp-buffer-size=4 -D_FORTIFY_SOURCE=2"
+go install -buildmode=pie -ldflags "-s -w -linkmode=external -extldflags '-z relro -z now' -X github.com/ARGOeu/argo-api-authn/version.Commit=$GIT_COMMIT -X github.com/ARGOeu/argo-api-authn/version.BuildTime=$BUILD_TIME"
 
 %files
 %defattr(0644,argo-api-authn,argo-api-authn)

--- a/auth/revoke.go
+++ b/auth/revoke.go
@@ -123,7 +123,7 @@ func CRLCheckRevokedCert(cert *x509.Certificate) error {
 	return err
 }
 
-// CheckInCRL checks if a serial number exists within the serial numbers of other revoked certificates
+// SynchronizedCheckInCRL checks if a serial number exists within the serial numbers of other revoked certificates
 func SynchronizedCheckInCRL(doneChan <-chan bool, errChan chan<- error, revokedCerts []pkix.RevokedCertificate, serialNumber *big.Int, wg *sync.WaitGroup) {
 
 loop:

--- a/auth/revoke_test.go
+++ b/auth/revoke_test.go
@@ -29,7 +29,9 @@ func ParseCert(pemData string) *x509.Certificate {
 }
 
 // 2014/05/22 14:18:31 Serial number match: intermediate is revoked.
+//
 //	2014/05/22 14:18:31 certificate is revoked via CRL
+//
 // 2014/05/22 14:18:31 Revoked certificate: misc/intermediate_ca/MobileArmorEnterpriseCA.crt
 var revokedCert = `-----BEGIN CERTIFICATE-----
 MIIEEzCCAvugAwIBAgILBAAAAAABGMGjftYwDQYJKoZIhvcNAQEFBQAwcTEoMCYG

--- a/bindings/binding.go
+++ b/bindings/binding.go
@@ -36,7 +36,7 @@ type BindingList struct {
 	Bindings []Binding `json:"bindings"`
 }
 
-//CreateBinding creates a new binding after validating its context
+// CreateBinding creates a new binding after validating its context
 func CreateBinding(binding Binding, store stores.Store) (Binding, error) {
 
 	var qBinding stores.QBinding
@@ -204,7 +204,7 @@ func FindAllBindings(store stores.Store) (BindingList, error) {
 
 }
 
-//FindBindingsByServiceTypeAndHost returns all the bindings of a specific service type and host
+// FindBindingsByServiceTypeAndHost returns all the bindings of a specific service type and host
 func FindBindingsByServiceTypeAndHost(serviceUUID string, host string, store stores.Store) (BindingList, error) {
 
 	var qBindings []stores.QBinding
@@ -258,7 +258,7 @@ func FindBindingByUUIDAndName(uuid, name string, store stores.Store) (Binding, e
 	return binding, err
 }
 
-//UpdateBinding updates a binding after validating its fields
+// UpdateBinding updates a binding after validating its fields
 func UpdateBinding(original Binding, tempBind TempUpdateBinding, store stores.Store) (Binding, error) {
 
 	var err error

--- a/config/config.go
+++ b/config/config.go
@@ -72,7 +72,7 @@ func (cfg *Config) ConfigSetUp(path string) error {
 	return nil
 }
 
-// ClintAuthPolicy determines, based on the given configuration what client authentication policy should the server follow
+// ClientAuthPolicy determines, based on the given configuration what client authentication policy should the server follow
 func (cfg *Config) ClientAuthPolicy() tls.ClientAuthType {
 
 	var policy = tls.VerifyClientCertIfGiven

--- a/docs/swagger.yml
+++ b/docs/swagger.yml
@@ -25,6 +25,33 @@ tags:
 
 paths:
 
+  /version:
+    get:
+      summary: "List API Version information"
+      description: "List api version information such as release version, commit hash etc.Authorisation is required when we want to access the release field as well."
+      parameters:
+        - $ref: '#/parameters/ApiKey'
+      tags:
+        - Version
+      produces:
+        - "application/json"
+      responses:
+        200:
+          description: "Successful retrieval of version info"
+          schema:
+            $ref: "#/definitions/Version"
+
+  /health:
+    get:
+      summary: List the health status for authn
+      description: |
+        list health status
+      tags:
+        - Health Check
+      responses:
+        200:
+          description: Returns the health status
+
   /service-types:
     post:
       summary: Create a new service type
@@ -803,3 +830,21 @@ definitions:
           status:
             type: string
             description: status of the error
+
+  Version:
+    type: object
+    properties:
+      build_time:
+        type: string
+      golang:
+        type: string
+      compiler:
+        type: string
+      os:
+        type: string
+      architecture:
+        type: string
+      release:
+        type: string
+      distro:
+        type: string

--- a/docs/v1/docs/api_health.md
+++ b/docs/v1/docs/api_health.md
@@ -1,0 +1,30 @@
+# Health API Call
+
+## [GET] Health API Call
+
+This request returns whether the service is running or not.
+
+#### Request
+
+```
+GET /v1/health
+```
+
+### Example request
+
+```
+curl -X GET "https://{URL}/v1/health"
+```
+
+
+### Response
+
+If the request is successful, the response contains a 200 code.
+
+Success Response
+
+`200 OK`
+
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors

--- a/docs/v1/docs/api_version.md
+++ b/docs/v1/docs/api_version.md
@@ -1,0 +1,46 @@
+# Version API Call
+
+## [GET] Version API Call
+
+This request retrieves information about the service build, environment, etc.
+
+**NOTE** In order to also retrieve the `release` field you need to perform
+an authorised request otherwise the api call requires no auth token.
+#### Request
+
+```
+GET /v1/version
+```
+
+### Example request
+
+```
+curl -X GET -H "Content-Type: application/json"
+"https://{URL}/v1/version?key={key_in_the_config}"
+```
+
+
+### Response
+
+If the request is successful, the response contains the
+service version info.
+
+Success Response
+
+`200 OK`
+
+```
+{
+    "build_time": "2022-10-10T13:21:07Z",
+    "golang": "go1.14",
+    "compiler": "gc",
+    "os": "linux",
+    "architecture": "amd64",
+    "release": "1.0.0",
+    "distro": "CentOS Linux release 7.9.2009 (Core)",
+}
+ 
+```
+
+### Errors
+Please refer to section [Errors](api_errors.md) to see all possible Errors

--- a/docs/v1/mkdocs.yml
+++ b/docs/v1/mkdocs.yml
@@ -18,5 +18,7 @@ pages:
     - API Service Types: api_service_types.md
     - API Auth Methods: api_authmethods.md
     - API Certificate Functionality: auth_certificate.md
+    - API Version: api_version.md
+    - API Health: api_health.md
     - API Error Messages: api_errors.md
 theme: readthedocs

--- a/handlers/authmethods_handlers_test.go
+++ b/handlers/authmethods_handlers_test.go
@@ -819,7 +819,7 @@ func (suite *AuthMethodsHandlersTestSuite) TestAuthMethodUpdateOne() {
 	amU, _ := mockstore.QueryApiKeyAuthMethods("uuid1", "host1")
 	expRespJSON = strings.Replace(expRespJSON, "{{UPDATED_ON}}", amU[0].UpdatedOn, 1)
 	// make sure the updated time is before now
-	updatedTime, _ := time.Parse(utils.ZULU_FORM, amU[0].UpdatedOn)
+	updatedTime, _ := time.Parse(utils.ZuluForm, amU[0].UpdatedOn)
 	suite.True(updatedTime.Before(time.Now().UTC()))
 	suite.Equal(200, w.Code)
 	suite.Equal(expRespJSON, w.Body.String())
@@ -864,7 +864,7 @@ func (suite *AuthMethodsHandlersTestSuite) TestAuthMethodUpdateOneIllegalFields(
 	amU, _ := mockstore.QueryApiKeyAuthMethods("uuid1", "host1")
 	expRespJSON = strings.Replace(expRespJSON, "{{UPDATED_ON}}", amU[0].UpdatedOn, 1)
 	// make sure the updated time is before now
-	updatedTime, _ := time.Parse(utils.ZULU_FORM, amU[0].UpdatedOn)
+	updatedTime, _ := time.Parse(utils.ZuluForm, amU[0].UpdatedOn)
 	suite.True(updatedTime.Before(time.Now().UTC()))
 	suite.Equal(200, w.Code)
 	suite.Equal(expRespJSON, w.Body.String())

--- a/handlers/binding_handlers_test.go
+++ b/handlers/binding_handlers_test.go
@@ -890,7 +890,7 @@ func (suite *BindingHandlersSuite) TestBindingUpdate() {
 	qB, _ := mockstore.QueryBindingsByUUIDAndName("b_uuid1", "updated_name")
 	expRespJSON = strings.Replace(expRespJSON, "{{UPDATED_ON}}", qB[0].UpdatedOn, 1)
 	// make sure the updated time is before now
-	updatedTime, _ := time.Parse(utils.ZULU_FORM, qB[0].UpdatedOn)
+	updatedTime, _ := time.Parse(utils.ZuluForm, qB[0].UpdatedOn)
 	suite.True(updatedTime.Before(time.Now().UTC()))
 
 	suite.Equal(200, w.Code)

--- a/handlers/generic_handlers_test.go
+++ b/handlers/generic_handlers_test.go
@@ -1,0 +1,110 @@
+package handlers
+
+import (
+	"fmt"
+	"github.com/ARGOeu/argo-api-authn/config"
+	"github.com/ARGOeu/argo-api-authn/stores"
+	"github.com/ARGOeu/argo-api-authn/version"
+	"github.com/gorilla/mux"
+	LOGGER "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/suite"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+type GenericHandlerSuite struct {
+	suite.Suite
+}
+
+func (suite *GenericHandlerSuite) TestListVersionUnauthorised() {
+
+	// set up cfg
+	cfg := &config.Config{}
+	_ = cfg.ConfigSetUp("../config/configuration-test-files/test-conf.json")
+
+	str := stores.Mockstore{}
+
+	req, err := http.NewRequest("GET", "http://localhost:8080/v1/version", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	expResp := `{
+ "build_time": "%v",
+ "golang": "%v",
+ "compiler": "%v",
+ "os": "%v",
+ "architecture": "%v",
+ "distro": "%v"
+}`
+	expResp = fmt.Sprintf(expResp, version.BuildTime, version.GO, version.Compiler,
+		version.OS, version.Arch, version.Distro)
+
+	router := mux.NewRouter().StrictSlash(true)
+	w := httptest.NewRecorder()
+	router.HandleFunc("/v1/version", WrapConfig(ListVersion, &str, cfg))
+	router.ServeHTTP(w, req)
+	suite.Equal(200, w.Code)
+	suite.Equal(expResp, w.Body.String())
+}
+
+func (suite *GenericHandlerSuite) TestListVersionAuthorised() {
+
+	// set up cfg
+	cfg := &config.Config{}
+	_ = cfg.ConfigSetUp("../config/configuration-test-files/test-conf.json")
+
+	str := stores.Mockstore{}
+
+	req, err := http.NewRequest("GET", "http://localhost:8080/v1/version?key=token", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	expResp := `{
+ "build_time": "%v",
+ "golang": "%v",
+ "compiler": "%v",
+ "os": "%v",
+ "architecture": "%v",
+ "release": "%v",
+ "distro": "%v"
+}`
+	expResp = fmt.Sprintf(expResp, version.BuildTime, version.GO, version.Compiler,
+		version.OS, version.Arch, version.Release, version.Distro)
+
+	router := mux.NewRouter().StrictSlash(true)
+	w := httptest.NewRecorder()
+	router.HandleFunc("/v1/version", WrapConfig(ListVersion, &str, cfg))
+	router.ServeHTTP(w, req)
+	suite.Equal(200, w.Code)
+	suite.Equal(expResp, w.Body.String())
+}
+
+func (suite *GenericHandlerSuite) TestHealthCheck() {
+
+	// set up cfg
+	cfg := &config.Config{}
+	_ = cfg.ConfigSetUp("../config/configuration-test-files/test-conf.json")
+
+	str := stores.Mockstore{}
+
+	req, err := http.NewRequest("GET", "http://localhost:8080/v1/health", nil)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	router := mux.NewRouter().StrictSlash(true)
+	w := httptest.NewRecorder()
+	router.HandleFunc("/v1/health", WrapConfig(ListVersion, &str, cfg))
+	router.ServeHTTP(w, req)
+	suite.Equal(200, w.Code)
+}
+
+func TestGenericHandlerTestSuite(t *testing.T) {
+	LOGGER.SetOutput(ioutil.Discard)
+	suite.Run(t, new(GenericHandlerSuite))
+}

--- a/handlers/service_type_handlers_test.go
+++ b/handlers/service_type_handlers_test.go
@@ -701,7 +701,7 @@ func (suite *BindingHandlersSuite) TestServiceTypeUpdate() {
 	qSt, _ := mockstore.QueryServiceTypes("updated_name")
 	expRespJSON = strings.Replace(expRespJSON, "{{UPDATED_ON}}", qSt[0].UpdatedOn, 1)
 	// make sure the updated time is before now
-	updatedTime, _ := time.Parse(utils.ZULU_FORM, qSt[0].UpdatedOn)
+	updatedTime, _ := time.Parse(utils.ZuluForm, qSt[0].UpdatedOn)
 	suite.True(updatedTime.Before(time.Now().UTC()))
 	suite.Equal(200, w.Code)
 	suite.Equal(expRespJSON, w.Body.String())

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/ARGOeu/argo-api-authn/version"
 	"net/http"
 
 	"github.com/gorilla/handlers"
@@ -20,6 +21,9 @@ import (
 
 func init() {
 	log.SetFormatter(&log.TextFormatter{FullTimestamp: true, DisableColors: true})
+
+	// display binary version information during start up
+	version.LogInfo()
 }
 
 func main() {

--- a/routing/routing.go
+++ b/routing/routing.go
@@ -86,4 +86,6 @@ var ApiRoutes = []APIRoute{
 	{"bindings:ListOneByName", "GET", "/bindings/{name}", handlers.BindingListOneByName, true},
 	{"bindings:Delete", "DELETE", "/bindings/{name}", handlers.BindingDelete, true},
 	{"auth:Map", "GET", "/service-types/{service-type}/hosts/{host}:authx509", handlers.AuthViaCert, false},
+	{"version:list", "GET", "/version", handlers.ListVersion, false},
+	{"version:list", "GET", "/health", handlers.HealthCheck, false},
 }

--- a/servicetypes/service_type.go
+++ b/servicetypes/service_type.go
@@ -199,7 +199,7 @@ func FindAllServiceTypes(store stores.Store) (ServiceTypesList, error) {
 
 }
 
-// hsHost returns whether or not a host is associated with a service type
+// HasHost returns whether or not a host is associated with a service type
 func (s *ServiceType) HasHost(host string) bool {
 
 	flag := false
@@ -290,7 +290,7 @@ func (s *ServiceType) IsOfValidType(cfg config.Config) error {
 	return err
 }
 
-//UpdateServiceType updates a binding after validating its fields
+// UpdateServiceType updates a binding after validating its fields
 func UpdateServiceType(original ServiceType, tempServiceType TempServiceType, store stores.Store, cfg config.Config) (ServiceType, error) {
 
 	var err error

--- a/stores/mongo.go
+++ b/stores/mongo.go
@@ -287,7 +287,7 @@ func (mongo *MongoStore) QueryBindings(serviceUUID string, host string) ([]QBind
 	return qBindings, err
 }
 
-//InsertServiceType inserts a new service into the datastore
+// InsertServiceType inserts a new service into the datastore
 func (mongo *MongoStore) InsertServiceType(name string, hosts []string, authTypes []string, authMethod string, uuid string, createdOn string, sType string) (QServiceType, error) {
 
 	var qService QServiceType
@@ -312,7 +312,7 @@ func (mongo *MongoStore) InsertServiceType(name string, hosts []string, authType
 	return qService, err
 }
 
-//InsertBinding inserts a new binding into the datastore
+// InsertBinding inserts a new binding into the datastore
 func (mongo *MongoStore) InsertBinding(name string, serviceUUID string, host string, uuid string, authID string, uniqueKey string, authType string) (QBinding, error) {
 
 	var qBinding QBinding
@@ -347,7 +347,7 @@ func (mongo *MongoStore) InsertBinding(name string, serviceUUID string, host str
 	return qBinding, err
 }
 
-//UpdateBinding updates the given binding
+// UpdateBinding updates the given binding
 func (mongo *MongoStore) UpdateBinding(original QBinding, updated QBinding) (QBinding, error) {
 
 	var err error
@@ -370,7 +370,7 @@ func (mongo *MongoStore) UpdateBinding(original QBinding, updated QBinding) (QBi
 	return updated, err
 }
 
-//UpdateServiceType updates the given binding
+// UpdateServiceType updates the given binding
 func (mongo *MongoStore) UpdateServiceType(original QServiceType, updated QServiceType) (QServiceType, error) {
 
 	var err error
@@ -438,7 +438,7 @@ func (mongo *MongoStore) DeleteServiceTypeByUUID(uuid string) error {
 	return err
 }
 
-// Delete binding deletes a binding from the store
+// DeleteBinding deletes a binding from the store
 func (mongo *MongoStore) DeleteBinding(qBinding QBinding) error {
 
 	var err error

--- a/utils/consts.go
+++ b/utils/consts.go
@@ -1,3 +1,3 @@
 package utils
 
-const ZULU_FORM = "2006-01-02T15:04:05Z"
+const ZuluForm = "2006-01-02T15:04:05Z"

--- a/utils/consts_test.go
+++ b/utils/consts_test.go
@@ -13,7 +13,7 @@ type ConstsTestSuite struct {
 func (suite *ConstsTestSuite) TestConsts() {
 
 	// test datetime Zulu format
-	suite.Equal("2006-01-02T15:04:05Z", ZULU_FORM)
+	suite.Equal("2006-01-02T15:04:05Z", ZuluForm)
 }
 
 func TestConstsTestSuite(t *testing.T) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -169,5 +169,5 @@ func CopyFields(from interface{}, to interface{}) error {
 
 // ZuluTimeNow returns the current UTC time in zulu format
 func ZuluTimeNow() string {
-	return time.Now().UTC().Format(ZULU_FORM)
+	return time.Now().UTC().Format(ZuluForm)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,99 @@
+package version
+
+import (
+	"os/exec"
+	"runtime"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+)
+
+var (
+	// Release version of the service. Bump it up during new version release
+	Release = "1.0.0"
+	// Commit hash provided during build
+	Commit = "Unknown"
+	// BuildTime provided during build
+	BuildTime = "Unknown"
+	// GO provides golang version
+	GO = runtime.Version()
+	// Distro provides extra information regarding the os distribution
+	Distro = "Unknown"
+	// Compiler info
+	Compiler = runtime.Compiler
+	// OS Info
+	OS = runtime.GOOS
+	// Arch info
+	Arch = runtime.GOARCH
+)
+
+func init() {
+	Distro = distro()
+}
+
+// LogInfo can be used to log version information during startup or termination etc...
+func LogInfo() {
+
+	log.WithFields(
+		log.Fields{
+			"type":         "service_log",
+			"release":      Release,
+			"commit":       Commit,
+			"build_time":   BuildTime,
+			"go":           GO,
+			"compiler":     Compiler,
+			"os":           OS,
+			"distro":       Distro,
+			"architecture": "Arch",
+		},
+	).Infof("Running Argo Messaging v%s (%s/%s)", Release, OS, Arch)
+}
+
+func distro() string {
+	// command line to execute in order to retrieve the os distribution in linux systems(ubuntu/centos)
+	if OS == "linux" {
+		cmd := exec.Command("cat", "/etc/redhat-release")
+		stdout, err := cmd.Output()
+		if err != nil {
+			cmd = exec.Command("lsb_release", "-ds")
+			stdout, err = cmd.Output()
+			if err != nil {
+				return ""
+			}
+		}
+		return strings.TrimSuffix(string(stdout), "\n")
+
+		// command line to execute in order to retrieve the os distribution in osx
+	} else if OS == "darwin" {
+		cmd := exec.Command("sw_vers", "-productName")
+		stdout, err := cmd.Output()
+		if err != nil {
+			return ""
+		}
+
+		pName := strings.TrimSuffix(string(stdout), "\n")
+
+		cmd = exec.Command("sw_vers", "-productVersion")
+		stdout, err = cmd.Output()
+		if err != nil {
+			return ""
+		}
+
+		pVersion := strings.TrimSuffix(string(stdout), "\n")
+
+		return pName + " " + pVersion
+	}
+
+	return ""
+}
+
+// Version struct holds version information about the binary build
+type Version struct {
+	BuildTime string `xml:"build_time" json:"build_time"`
+	GO        string `xml:"golang" json:"golang"`
+	Compiler  string `xml:"compiler" json:"compiler"`
+	OS        string `xml:"os" json:"os"`
+	Arch      string `xml:"architecture" json:"architecture"`
+	Release   string `xml:"release,omitempty" json:"release,omitempty"`
+	Distro    string `xml:"distro,omitempty" json:"distro,omitempty"`
+}


### PR DESCRIPTION
Add 2 new api calls
1) GET @ /v1/version that returns build,env, etc info sbout the service.The release information is hidden behind authentication

2) GET @ /v1/health which just acts as a ping

Few modification to the spec file in order to change the way we build the binary.Add security options and some extra data for the version api call