### PR TITLE
AM-315 Update user creations scripts to use ams library projects:createUser functionality

### DIFF
--- a/bin/argo-api-authn-scripts/ams-create-users-cloud-info.py
+++ b/bin/argo-api-authn-scripts/ams-create-users-cloud-info.py
@@ -459,9 +459,15 @@ def create_users(config, verify):
 
                 exists = False
                 try:
-                    # create the user
-                    created_ams_user = ams.create_user(user=user_create_data, verify=verify)
-                    LOGGER.info("Created user: " + created_ams_user.name)
+                    # create the project member user
+                    created_ams_user = ams.create_project_member(
+                        username=user_binding_name,
+                        project=ams_project,
+                        roles=[users_role],
+                        email=contact_email,
+                        verify=verify
+                    )
+                    LOGGER.info("Created project member user: " + created_ams_user.name)
                     ams_user_uuid = created_ams_user.uuid
                     user_count += 1
                 except AmsException as e:
@@ -470,7 +476,7 @@ def create_users(config, verify):
                     else:
                         LOGGER.error("User: " + user_binding_name)
                         LOGGER.error(
-                            "Something went wrong while creating ams user." +
+                            "Something went wrong while creating ams project member user." +
                             "\nError: " + str(e))
                         continue
 

--- a/bin/argo-api-authn-scripts/ams-create-users-gocdb.py
+++ b/bin/argo-api-authn-scripts/ams-create-users-gocdb.py
@@ -455,9 +455,15 @@ def create_users(config, verify):
 
                 exists = False
                 try:
-                    # create the user
-                    created_ams_user = ams.create_user(user=user_create_data, verify=verify)
-                    LOGGER.info("Created user: " + created_ams_user.name)
+                    # create the project member user
+                    created_ams_user = ams.create_project_member(
+                        username=user_binding_name,
+                        project=ams_project,
+                        roles=[users_role],
+                        email=contact_email,
+                        verify=verify
+                    )
+                    LOGGER.info("Created project member user: " + created_ams_user.name)
                     ams_user_uuid = created_ams_user.uuid
                     user_count += 1
                 except AmsException as e:
@@ -466,7 +472,7 @@ def create_users(config, verify):
                     else:
                         LOGGER.error("User: " + user_binding_name)
                         LOGGER.error(
-                            "Something went wrong while creating ams user." +
+                            "Something went wrong while creating ams project member user." +
                             "\nError: " + str(e))
                         continue
 

--- a/bin/requirements.txt
+++ b/bin/requirements.txt
@@ -1,4 +1,4 @@
 defusedxml==0.7.1
 python-ldap==3.4.0
-argo-ams-library==0.5.9
+argo-ams-library==0.6.1
 requests

--- a/setup.py
+++ b/setup.py
@@ -13,5 +13,5 @@ setup(
         './bin/argo-api-authn-scripts/ams-create-users-cloud-info.py'],
     package_dir={'argo_api_authn_scripts': './bin/argo-api-authn-scripts/'},
     packages=['argo_api_authn_scripts'],
-    install_requires=['defusedxml==0.7.1', 'python-ldap==3.4.0', 'argo-ams-library==0.5.9', 'requests']
+    install_requires=['defusedxml==0.7.1', 'python-ldap==3.4.0', 'argo-ams-library==0.6.1', 'requests']
     )


### PR DESCRIPTION
Since we want to use our scripts with non-service admins tokens, we needed to also update the user creation to utilize the project member API instead of the global user member API which is only accessible to service admins.