### PR TITLE
AM-335 authn: Configure https server connection timeouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,16 @@
 # Argo Api Authn
 
-[![Build Status](https://jenkins.einfra.grnet.gr/buildStatus/icon?job=ARGO%2Fargo-api-authn%2Fmaster&style=flat-square&color=darkturquoise&subject=build-master)](https://jenkins.einfra.grnet.gr/job/ARGO/job/argo-api-authn/job/master/) 
+[![Build Status](https://jenkins.einfra.grnet.gr/buildStatus/icon?job=ARGO%2Fargo-api-authn%2Fmaster&style=flat-square&color=darkturquoise&subject=build-master)](https://jenkins.einfra.grnet.gr/job/ARGO/job/argo-api-authn/job/master/)
 [![Build Status](https://jenkins.einfra.grnet.gr/buildStatus/icon?job=ARGO%2Fargo-api-authn%2Fdevel&style=flat-square&subject=build-devel)](https://jenkins.einfra.grnet.gr/job/ARGO/job/argo-api-authn/job/devel/)
 
 Authentication Service for ARGO API(s)
 
-
 ## Description
 
-The purpose of the Authentication Service is to provide the ability to different services to use alternative authentication mechanisms without having to store additional user info or implement new functionalities.The AUTH service holds various information about a service’s users, hosts, API urls, etc, and leverages them to provide its functionality. 
+The purpose of the Authentication Service is to provide the ability to different services to use alternative
+authentication mechanisms without having to store additional user info or implement new functionalities.The AUTH service
+holds various information about a service’s users, hosts, API urls, etc, and leverages them to provide its
+functionality.
 
 ## Perquisites
 
@@ -19,108 +21,128 @@ Before you start, you need to issue a valid certificate.
 1. Install Golang 1.14
 2. Create a new work space:
 
-      `mkdir ~/go-workspace`
-      
-      `export GOPATH=~/go-workspace`
-      
-      `export PATH=$PATH:$GOPATH/bin`
+   `mkdir ~/go-workspace`
 
-     You may add the last `export` line into the `~/.bashrc`, `/.zshrc` or the `~/.bash_profile` file to have `GOPATH` environment variable properly setup upon every login.
+   `export GOPATH=~/go-workspace`
+
+   `export PATH=$PATH:$GOPATH/bin`
+
+   You may add the last `export` line into the `~/.bashrc`, `/.zshrc` or the `~/.bash_profile` file to have `GOPATH`
+   environment variable properly setup upon every login.
 
 3. Get the latest version
 
-      `go get github.com/ARGOeu/argo-api-authn`
+   `go get github.com/ARGOeu/argo-api-authn`
 
 4. Get dependencies(If you plan on contributing to the project else skip this step):
 
    Argo-api-authN uses the go modules tool for dependency handling.
-    
+
 5. To build the service use the following command:
 
-      `go build`
+   `go build`
 
 6. To run the service use the following command:
 
-      `./argo-api-authn` (This assumes that there is a valid configuration file at `/etc/argo-api-authn/conf.d/argo-api-authn-config.json`).
-      
-      Else
-      
-      `./argo-api-authn --config /path/to/a/json/config/file`
+   `./argo-api-authn` (This assumes that there is a valid configuration file
+   at `/etc/argo-api-authn/conf.d/argo-api-authn-config.json`).
+
+   Else
+
+   `./argo-api-authn --config /path/to/a/json/config/file`
 
 7. To run the unit-tests:
 
-    Inside the project's folder issue the command:
+   Inside the project's folder issue the command:
 
-      `go test $(go list ./... | grep -v /vendor/)`
- 
- 8. Install mongoDB
- 
- 
- ## Configuration
- 
- The service depends on a configuration file in order to be able to run.This file contains the following information:
- 
+   `go test $(go list ./... | grep -v /vendor/)`
+
+8. Install mongoDB
+
+## Configuration
+
+The service depends on a configuration file in order to be able to run.This file contains the following information:
+
  ```json
  {
-   "service_port":8080,
-   "mongo_host":"mongo_host",
-   "mongo_db":"mongo database",
-   "certificate_authorities":"/path/to/cas/certificates/",
-   "certificate":"/path/to/cert/localhost.crt",
-   "certificate_key":"/path/to/key/localhost.key",
-   "service_token": "some-token",
-   "supported_auth_types": ["x509"],
-   "supported_auth_methods": ["api-key", "headers"],
-   "supported_service_types": ["ams", "web-api"],
-   "verify_ssl": true,
-   "trust_unknown_cas": false,
-   "verify_certificate": true,
-   "service_types_paths": {
+  "service_port": 8080,
+  "mongo_host": "mongo_host",
+  "mongo_db": "mongo database",
+  "certificate_authorities": "/path/to/cas/certificates/",
+  "certificate": "/path/to/cert/localhost.crt",
+  "certificate_key": "/path/to/key/localhost.key",
+  "service_token": "some-token",
+  "supported_auth_types": [
+    "x509"
+  ],
+  "supported_auth_methods": [
+    "api-key",
+    "headers"
+  ],
+  "supported_service_types": [
+    "ams",
+    "web-api"
+  ],
+  "verify_ssl": true,
+  "trust_unknown_cas": false,
+  "verify_certificate": true,
+  "service_types_paths": {
     "ams": "/v1/users:byUUID/{{identifier}}",
     "web-api": "/api/v2/users:byID/{{identifier}}?export=flat"
-    },
-   "service_types_retrieval_fields": {
-   "ams": "token",
-   "web-api": "api_key"
-   },
-   "syslog_enabled": true,
-   "client_cert_host_verification": true
- }
+  },
+  "service_types_retrieval_fields": {
+    "ams": "token",
+    "web-api": "api_key"
+  },
+  "syslog_enabled": true,
+  "client_cert_host_verification": true,
+  "server_read_timeout": 5,
+  "server_header_read_timeout": 5,
+  "server_write_timeout": 15,
+  "server_idle_timeout": 60
+}
  ```
- 
- ## Important Notes
-It is important to notice that since we need to verify the provided certificate’s hostname, 
-the client has to make sure that both Forward and  Reverse DNS lookup on the client is correctly setup 
-and that the hostname  corresponds to the certificate used.  For both IPv4 and IPv6  (if used). 
+
+## Important Notes
+
+It is important to notice that since we need to verify the provided certificate’s hostname,
+the client has to make sure that both Forward and Reverse DNS lookup on the client is correctly setup
+and that the hostname corresponds to the certificate used. For both IPv4 and IPv6  (if used).
 This functionality is controlled by the configuration ` client_cert_host_verification` value.
- 
- ### Common errors
- - Executing a request using IPv6 without having a properly configured reverse DNS.
+
+### Common errors
+
+- Executing a request using IPv6 without having a properly configured reverse DNS.
+
  ```json
  {
- "error": {
-  "message": "lookup *.*.*.*.*.*..... .ip6.arpa. on <ip from where the client executed the request>: no such host",
-  "code": 400,
-  "status": "BAD REQUEST"
-   }
- }
-```
-- Executing a request from a host that is not registered on the certificate.
-
-A common case for this error is to have the FQDN registered on the certificate 
-but a reverse dns look up returns another hostname for the client from where the request was executed. 
-```json
-{
- "error": {
-  "message": "x509: certificate is valid for host1, host2, not host3.",
-  "code": 403,
-  "status": "ACCESS_FORBIDDEN"
- }
+  "error": {
+    "message": "lookup *.*.*.*.*.*..... .ip6.arpa. on <ip from where the client executed the request>: no such host",
+    "code": 400,
+    "status": "BAD REQUEST"
+  }
 }
 ```
- ## Helpful Utilities
- You can find various utility scripts to help you get up and running the service inside the
- repo's `bin` folder. You can also find the respective documentation for the scripts inside the `docs` folder.
+
+- Executing a request from a host that is not registered on the certificate.
+
+A common case for this error is to have the FQDN registered on the certificate
+but a reverse dns look up returns another hostname for the client from where the request was executed.
+
+```json
+{
+  "error": {
+    "message": "x509: certificate is valid for host1, host2, not host3.",
+    "code": 403,
+    "status": "ACCESS_FORBIDDEN"
+  }
+}
+```
+
+## Helpful Utilities
+
+You can find various utility scripts to help you get up and running the service inside the
+repo's `bin` folder. You can also find the respective documentation for the scripts inside the `docs` folder.
 
 ## Feature Milestones
 

--- a/conf/argo-api-authn-config.template
+++ b/conf/argo-api-authn-config.template
@@ -1,19 +1,37 @@
 {
-  "service_port":8081,
-  "mongo_host":"localhost",
-  "mongo_db":"argo_auth",
-  "certificate_authorities":"/etc/grid-security/certificates",
-  "certificate":"/etc/pki/tls/certs/localhost.crt",
-  "certificate_key":"/etc/pki/tls/private/localhost.key",
+  "service_port": 8081,
+  "mongo_host": "localhost",
+  "mongo_db": "argo_auth",
+  "certificate_authorities": "/etc/grid-security/certificates",
+  "certificate": "/etc/pki/tls/certs/localhost.crt",
+  "certificate_key": "/etc/pki/tls/private/localhost.key",
   "service_token": "agelos",
-  "supported_auth_types": ["x509", "oidc"],
-  "supported_auth_methods": ["api-key", "headers"],
-  "supported_service_types": ["ams", "web-api", "custom"],
+  "supported_auth_types": [
+    "x509",
+    "oidc"
+  ],
+  "supported_auth_methods": [
+    "api-key",
+    "headers"
+  ],
+  "supported_service_types": [
+    "ams",
+    "web-api",
+    "custom"
+  ],
   "verify_ssl": false,
   "trust_unknown_cas": true,
   "verify_certificate": false,
-  "service_types_paths": {"ams": "/v1/users:byUUID/{{identifier}}"},
-  "service_types_retrieval_fields": {"ams": "token"},
+  "service_types_paths": {
+    "ams": "/v1/users:byUUID/{{identifier}}"
+  },
+  "service_types_retrieval_fields": {
+    "ams": "token"
+  },
   "syslog_enabled": false,
-  "client_cert_host_verification" : false
+  "client_cert_host_verification": false,
+  "server_read_timeout": 5,
+  "server_header_read_timeout": 5,
+  "server_write_timeout": 15,
+  "server_idle_timeout": 60
 }

--- a/config.json
+++ b/config.json
@@ -1,14 +1,23 @@
 {
-  "service_port":9000,
-  "mongo_host":"test_host",
-  "mongo_db":"test_db",
-  "certificate_authorities":"/path/to/cas",
-  "certificate":"/path/to/cert",
-  "certificate_key":"/path/to/key",
+  "service_port": 9000,
+  "mongo_host": "test_host",
+  "mongo_db": "test_db",
+  "certificate_authorities": "/path/to/cas",
+  "certificate": "/path/to/cert",
+  "certificate_key": "/path/to/key",
   "service_token": "token",
-  "supported_auth_types": ["x509"],
-  "supported_auth_methods": ["api-key", "headers"],
-  "supported_service_types": ["ams", "web-api", "custom"],
+  "supported_auth_types": [
+    "x509"
+  ],
+  "supported_auth_methods": [
+    "api-key",
+    "headers"
+  ],
+  "supported_service_types": [
+    "ams",
+    "web-api",
+    "custom"
+  ],
   "verify_ssl": true,
   "trust_unknown_cas": false,
   "verify_certificate": true,
@@ -20,5 +29,9 @@
     "ams": "token",
     "web-api": "api_key"
   },
-  "syslog_enabled" : false
+  "syslog_enabled": false,
+  "server_read_timeout": 5,
+  "server_header_read_timeout": 5,
+  "server_write_timeout": 15,
+  "server_idle_timeout": 60
 }

--- a/config/config.go
+++ b/config/config.go
@@ -12,6 +12,13 @@ import (
 	"reflect"
 )
 
+const (
+	DefaultServerReadTimeout       = 5
+	DefaultServerHeaderReadTimeout = 5
+	DefaultServerWriteTimeout      = 15
+	DefaultServerIdleTimeout       = 60
+)
+
 type Config struct {
 	ServicePort                 int               `json:"service_port" required:"true"`
 	MongoHost                   string            `json:"mongo_host" required:"true"`
@@ -30,6 +37,20 @@ type Config struct {
 	ServiceTypesRetrievalFields map[string]string `json:"service_types_retrieval_fields" required:"true"`
 	SyslogEnabled               bool              `json:"syslog_enabled"`
 	ClientCertHostVerification  bool              `json:"client_cert_host_verification"`
+	ServerReadTimeout           int               `json:"server_read_timeout"`
+	ServerHeaderReadTimeout     int               `json:"server_header_read_timeout"`
+	ServerWriteTimeout          int               `json:"server_write_timeout"`
+	ServerIdleTimeout           int               `json:"server_idle_timeout"`
+}
+
+func WithDefaults() *Config {
+	return &Config{
+		ServerReadTimeout:       DefaultServerReadTimeout,
+		ServerHeaderReadTimeout: DefaultServerHeaderReadTimeout,
+		ServerWriteTimeout:      DefaultServerWriteTimeout,
+		ServerIdleTimeout:       DefaultServerIdleTimeout,
+	}
+
 }
 
 // ConfigSetUp unmarshalls a json file specified by the input parameter into the config object

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,6 +11,14 @@ type ConfigTestSuite struct {
 	suite.Suite
 }
 
+func (suite *ConfigTestSuite) TestWithDefaults() {
+	cfg := WithDefaults()
+	suite.Equal(5, cfg.ServerReadTimeout)
+	suite.Equal(5, cfg.ServerHeaderReadTimeout)
+	suite.Equal(15, cfg.ServerWriteTimeout)
+	suite.Equal(60, cfg.ServerIdleTimeout)
+}
+
 func (suite *ConfigTestSuite) TestConfigSetUp() {
 
 	// tests the case of a wrong path to a config file
@@ -18,7 +26,11 @@ func (suite *ConfigTestSuite) TestConfigSetUp() {
 	err1 := cfg1.ConfigSetUp("/wrong/path")
 
 	// tests the case of a normal setup
-	cfg2 := &Config{}
+	cfg2 := WithDefaults()
+	suite.Equal(5, cfg2.ServerReadTimeout)
+	suite.Equal(5, cfg2.ServerHeaderReadTimeout)
+	suite.Equal(15, cfg2.ServerWriteTimeout)
+	suite.Equal(60, cfg2.ServerIdleTimeout)
 	err2 := cfg2.ConfigSetUp("./configuration-test-files/test-conf.json")
 	expCfg2 := &Config{
 		ServicePort:            9000,
@@ -44,6 +56,10 @@ func (suite *ConfigTestSuite) TestConfigSetUp() {
 		},
 		SyslogEnabled:              true,
 		ClientCertHostVerification: true,
+		ServerReadTimeout:          15,
+		ServerHeaderReadTimeout:    15,
+		ServerWriteTimeout:         15,
+		ServerIdleTimeout:          120,
 	}
 
 	//tests the case of a malformed json

--- a/config/configuration-test-files/test-conf.json
+++ b/config/configuration-test-files/test-conf.json
@@ -1,14 +1,24 @@
 {
-  "service_port":9000,
-  "mongo_host":"test_mongo_host",
-  "mongo_db":"test_mongo_db",
-  "certificate_authorities":"/path/to/cas",
-  "certificate":"/path/to/cert",
-  "certificate_key":"/path/to/key",
+  "service_port": 9000,
+  "mongo_host": "test_mongo_host",
+  "mongo_db": "test_mongo_db",
+  "certificate_authorities": "/path/to/cas",
+  "certificate": "/path/to/cert",
+  "certificate_key": "/path/to/key",
   "service_token": "token",
-  "supported_auth_types": ["x509", "oidc"],
-  "supported_auth_methods": ["api-key", "headers"],
-  "supported_service_types": ["ams", "web-api", "custom"],
+  "supported_auth_types": [
+    "x509",
+    "oidc"
+  ],
+  "supported_auth_methods": [
+    "api-key",
+    "headers"
+  ],
+  "supported_service_types": [
+    "ams",
+    "web-api",
+    "custom"
+  ],
   "ssl_verify": true,
   "trust_unknown_cas": false,
   "verify_certificate": true,
@@ -21,5 +31,9 @@
     "web-api": "api_key"
   },
   "syslog_enabled": true,
-  "client_cert_host_verification": true
+  "client_cert_host_verification": true,
+  "server_read_timeout": 15,
+  "server_header_read_timeout": 15,
+  "server_write_timeout": 15,
+  "server_idle_timeout": 120
 }

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"github.com/ARGOeu/argo-api-authn/version"
 	"net/http"
+	"time"
 
 	"github.com/gorilla/handlers"
 
@@ -34,7 +35,7 @@ func main() {
 	flag.Parse()
 
 	// initialize the config
-	var cfg = &config.Config{}
+	var cfg = config.WithDefaults()
 	if err := cfg.ConfigSetUp(*cfgPath); err != nil {
 		log.Error(err.Error())
 		panic(err.Error())
@@ -62,9 +63,13 @@ func main() {
 	allowVerbs := handlers.AllowedMethods([]string{"OPTIONS", "POST", "GET", "PUT", "DELETE", "HEAD"})
 
 	server := &http.Server{
-		Addr:      ":" + strconv.Itoa(cfg.ServicePort),
-		Handler:   handlers.CORS(xReqWithConType, allowVerbs)(api.Router),
-		TLSConfig: tlsConfig,
+		Addr:              ":" + strconv.Itoa(cfg.ServicePort),
+		Handler:           handlers.CORS(xReqWithConType, allowVerbs)(api.Router),
+		TLSConfig:         tlsConfig,
+		ReadTimeout:       time.Duration(cfg.ServerReadTimeout) * time.Second,
+		ReadHeaderTimeout: time.Duration(cfg.ServerHeaderReadTimeout) * time.Second,
+		WriteTimeout:      time.Duration(cfg.ServerWriteTimeout) * time.Second,
+		IdleTimeout:       time.Duration(cfg.ServerIdleTimeout) * time.Second,
 	}
 
 	//Start the server


### PR DESCRIPTION
Since authn is directly exposed to the internet without any proxy in front of it, it needs a better configured https server.

Also the last couple months we have encountered the below issue a few times which is an indicator of leaked resources.
argo_api_authn: 2023/09/12 03:44:55 http: Accept error: accept tcp [::]:8443: accept4: too many open files; retrying in 1s

https://blog.cloudflare.com/exposing-go-on-the-internet/