### PR TITLE
New release 1.2.0

### DIFF
--- a/argo-api-authn.spec
+++ b/argo-api-authn.spec
@@ -3,7 +3,7 @@
 
 Name: argo-api-authn
 Summary: ARGO Authentication API. Map X509, OICD to token.
-Version: 1.1.0
+Version: 1.2.0
 Release: 1%{?dist}
 License: ASL 2.0
 Buildroot: %{_tmppath}/%{name}-buildroot
@@ -60,6 +60,8 @@ go install -buildmode=pie -ldflags "-s -w -linkmode=external -extldflags '-z rel
 %attr(0644,root,root) /usr/lib/systemd/system/argo-api-authn.service
 
 %changelog
+* Tue Dec 19 2023 Agelos Tsalapatis  <agelos.tsal@gmail.com> - 1.2.0-1%{?dist}
+- Release of argo-api-authn version 1.1.0
 * Tue Sep 26 2023 Agelos Tsalapatis  <agelos.tsal@gmail.com> - 1.1.0-1%{?dist}
 - Release of argo-api-authn version 1.1.0
 * Mon Oct 10 2022 Agelos Tsalapatis  <agelos.tsal@gmail.com> - 1.0.0-1%{?dist}

--- a/version/version.go
+++ b/version/version.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	// Release version of the service. Bump it up during new version release
-	Release = "1.1.0"
+	Release = "1.2.0"
 	// Commit hash provided during build
 	Commit = "Unknown"
 	// BuildTime provided during build


### PR DESCRIPTION
AM-330 authn: Integration tests for mongo 5.0 and mgo driver
AM-39 Enable again health check & version api calls
Update authn_ci-cd_tests.postman_collection.json
AM-343 Improper handling of errors during Fetch CRL functionality
AM-41 Authn upgrade to go 1.19
