### PR TITLE
New Release 1.4.0

### DIFF
--- a/argo-api-authn.spec
+++ b/argo-api-authn.spec
@@ -3,7 +3,7 @@
 
 Name: argo-api-authn
 Summary: ARGO Authentication API. Map X509, OICD to token.
-Version: 1.3.0
+Version: 1.4.0
 Release: 1%{?dist}
 License: ASL 2.0
 Buildroot: %{_tmppath}/%{name}-buildroot
@@ -60,6 +60,8 @@ go install -buildmode=pie -ldflags "-s -w -linkmode=external -extldflags '-z rel
 %attr(0644,root,root) /usr/lib/systemd/system/argo-api-authn.service
 
 %changelog
+* Mon May 27 2024 Agelos Tsalapatis  <agelos.tsal@gmail.com> - 1.3.0-1%{?dist}
+- Release of argo-api-authn version 1.4.0
 * Wed Jan 24 2024 Agelos Tsalapatis  <agelos.tsal@gmail.com> - 1.3.0-1%{?dist}
 - Release of argo-api-authn version 1.3.0
 * Tue Dec 19 2023 Agelos Tsalapatis  <agelos.tsal@gmail.com> - 1.2.0-1%{?dist}

--- a/version/version.go
+++ b/version/version.go
@@ -10,7 +10,7 @@ import (
 
 var (
 	// Release version of the service. Bump it up during new version release
-	Release = "1.3.0"
+	Release = "1.4.0"
 	// Commit hash provided during build
 	Commit = "Unknown"
 	// BuildTime provided during build


### PR DESCRIPTION
**New features/Enchantments**
- AM-356 Authn Compatibility with mongo 6
- AM-354 authn: Upgrade to Golang version 1.21.6


**Fixes**
- AM-354 FetchCrl should still use deprecated standard